### PR TITLE
Add cursor-agent (Cursor CLI) harness adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ npm install -g pnpm@10.9.0
 Install and sign in to at least one supported agent:
 [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started),
 [Codex](https://github.com/openai/codex),
+[Cursor](https://cursor.com/cli),
 [Gemini](https://github.com/google-gemini/gemini-cli),
 [Copilot](https://docs.github.com/en/copilot/how-tos/copilot-cli/cli-getting-started), or
 [OpenCode](https://opencode.ai/docs/).

--- a/packages/adapters/cursor/NOTES.md
+++ b/packages/adapters/cursor/NOTES.md
@@ -1,0 +1,52 @@
+# cursor adapter — behavioral sources
+
+Drives the `cursor-agent` CLI in headless mode. Mirrors the `gemini` adapter
+(per-turn subprocess + `--output-format stream-json` + readline over stdout).
+Captured against `cursor-agent 2026.07.16-899851b`.
+
+## Invocation
+
+```
+cursor-agent -p --output-format stream-json --stream-partial-output --trust \
+  [--model <m>] [<policy flags>] [--resume <session_id>] -- <payload>
+```
+
+`--` guards payloads beginning with a dash. Prompt is a positional arg (no
+`--prompt` flag exists). `--trust` avoids the workspace-trust prompt in headless
+mode. Child `cwd` is the session cwd; `cursor-agent` defaults its workspace to cwd.
+
+## policy -> flags
+
+| canonical | flags | native label |
+| --- | --- | --- |
+| read-only | `--mode plan` | `plan` |
+| workspace-write | `--force --sandbox enabled` | `force+sandbox` |
+| full-access | `--force --sandbox disabled` | `yolo` |
+
+`--force` auto-runs tool calls (no interactive approval exists in headless
+`--print`). The OS sandbox (`--sandbox enabled`) confines shell/filesystem to the
+workspace for workspace-write; full-access disables it.
+
+## stream-json events (one JSON object per line)
+
+- `{type:'system', subtype:'init', session_id, model, apiKeySource:'login'}` —
+  session id announced here -> `hooks.onSessionRef`. `login` = subscription auth.
+- `{type:'user', ...}` — input echo; ignored.
+- `{type:'thinking', subtype:'delta'|'completed', text}` -> `reasoning_summary`.
+- `{type:'assistant', message:{content:[{type:'text',text}]}, timestamp_ms?}` —
+  events WITH `timestamp_ms` are incremental deltas -> `text_delta`; the one
+  WITHOUT is the cumulative echo and is skipped (else text doubles).
+- `{type:'tool_call', subtype:'started'|'completed', call_id, tool_call:{<name>ToolCall:{args,result}}}`
+  -> `tool_call` (started) / `tool_result` (completed). Tool name is the single
+  key minus the `ToolCall` suffix (e.g. `shellToolCall` -> `shell`). `result` with
+  a `success` key = ok, else error.
+- `{type:'result', subtype:'success', is_error, result, usage:{inputTokens,outputTokens,cacheReadTokens,cacheWriteTokens}}`
+  -> `run.completed` (final_text = `result`, usage mapped to input/output_tokens).
+
+## capabilities
+
+`resume:true` (via `--resume`), `discover:false` (`cursor-agent ls` needs a TTY /
+Ink raw mode, unusable headlessly — codor resumes from its own persisted
+session_ref, so discovery is not required), `ask:false`, `approvals:'spawn-time'`,
+`extensions:false`, `thinking:false` (effort is expressed inside the `--model`
+string, e.g. `claude-opus-4-8[effort=high]`), `live_inbox:false`.

--- a/packages/adapters/cursor/fixtures/SYNTHETIC.md
+++ b/packages/adapters/cursor/fixtures/SYNTHETIC.md
@@ -1,0 +1,14 @@
+# SYNTHETIC fixtures
+
+These files were synthesized from the `cursor-agent --output-format stream-json`
+event vocabulary documented in `../NOTES.md`. They mirror the shape of real CLI
+output but are not live captures and contain no model output obtained from an
+authenticated account.
+
+- `synthetic-success.jsonl` covers `system/init`, a user echo, a thinking delta,
+  a tool call and its result, streaming assistant deltas (with the trailing
+  cumulative echo that must be skipped), and a successful token-only result.
+- `synthetic-failure.jsonl` covers an errored terminal result.
+
+See `../NOTES.md` and the repository-root `MANUAL-VERIFY.md` for sources and the
+deferred authenticated probe.

--- a/packages/adapters/cursor/fixtures/synthetic-failure.jsonl
+++ b/packages/adapters/cursor/fixtures/synthetic-failure.jsonl
@@ -1,0 +1,2 @@
+{"type":"system","subtype":"init","apiKeySource":"login","cwd":"/work","session_id":"22222222-2222-4222-8222-222222222222","model":"Composer 2.5","permissionMode":"default"}
+{"type":"result","subtype":"error","duration_ms":5,"is_error":true,"result":"Authentication required","session_id":"22222222-2222-4222-8222-222222222222","usage":{"inputTokens":0,"outputTokens":0,"cacheReadTokens":0,"cacheWriteTokens":0}}

--- a/packages/adapters/cursor/fixtures/synthetic-success.jsonl
+++ b/packages/adapters/cursor/fixtures/synthetic-success.jsonl
@@ -1,0 +1,10 @@
+{"type":"system","subtype":"init","apiKeySource":"login","cwd":"/work","session_id":"11111111-1111-4111-8111-111111111111","model":"Composer 2.5","permissionMode":"default"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"Reply PONG"}]},"session_id":"11111111-1111-4111-8111-111111111111"}
+{"type":"thinking","subtype":"delta","text":"Reading the file.","session_id":"11111111-1111-4111-8111-111111111111","timestamp_ms":1}
+{"type":"thinking","subtype":"completed","session_id":"11111111-1111-4111-8111-111111111111","timestamp_ms":2}
+{"type":"tool_call","subtype":"started","call_id":"read-1","tool_call":{"readToolCall":{"args":{"path":"README.md"}}},"session_id":"11111111-1111-4111-8111-111111111111"}
+{"type":"tool_call","subtype":"completed","call_id":"read-1","tool_call":{"readToolCall":{"args":{"path":"README.md"},"result":{"success":{"content":"Codor","totalLines":1}}}},"session_id":"11111111-1111-4111-8111-111111111111"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"PO"}]},"session_id":"11111111-1111-4111-8111-111111111111","timestamp_ms":3}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"NG"}]},"session_id":"11111111-1111-4111-8111-111111111111","timestamp_ms":4}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"PONG"}]},"session_id":"11111111-1111-4111-8111-111111111111"}
+{"type":"result","subtype":"success","duration_ms":60,"is_error":false,"result":"PONG","session_id":"11111111-1111-4111-8111-111111111111","usage":{"inputTokens":12,"outputTokens":2,"cacheReadTokens":0,"cacheWriteTokens":0}}

--- a/packages/adapters/cursor/package.json
+++ b/packages/adapters/cursor/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@codor/adapter-cursor",
+  "version": "0.1.0",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@codor/protocol": "workspace:*"
+  }
+}

--- a/packages/adapters/cursor/src/adapter.spec.ts
+++ b/packages/adapters/cursor/src/adapter.spec.ts
@@ -1,0 +1,128 @@
+import { chmodSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { WireEvent } from '@codor/protocol';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { CursorAdapter, cursorArgs } from './adapter.js';
+
+const dirs: string[] = [];
+
+function executable(source: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'codor-cursor-adapter-'));
+  dirs.push(dir);
+  const path = join(dir, 'fake-cursor-agent');
+  writeFileSync(path, `#!/usr/bin/env node\n${source}`);
+  chmodSync(path, 0o755);
+  return path;
+}
+
+async function collect(adapter: CursorAdapter): Promise<WireEvent[]> {
+  const events: WireEvent[] = [];
+  for await (const event of adapter.deliver(adapter.spawn({ cwd: process.cwd() }), 'hello')) {
+    events.push(event);
+  }
+  return events;
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('cursor subprocess and capability conformance', () => {
+  it('maps Codor policy chips onto cursor-agent flags', () => {
+    const base = { harness: 'cursor', cwd: '/work' } as const;
+    expect(cursorArgs({ ...base, policy: 'read-only' }, 'go'))
+      .toEqual(expect.arrayContaining(['--mode', 'plan']));
+    expect(cursorArgs({ ...base, policy: 'workspace-write' }, 'go'))
+      .toEqual(expect.arrayContaining(['--force', '--sandbox', 'enabled']));
+    expect(cursorArgs({ ...base, policy: 'full-access' }, 'go'))
+      .toEqual(expect.arrayContaining(['--force', '--sandbox', 'disabled']));
+    expect(() => cursorArgs({ ...base, policy: 'plan' }, 'go')).toThrow('valid policies');
+    expect(() => cursorArgs({ ...base, thinking: 'high' }, 'go'))
+      .toThrow('does not support thinking');
+  });
+
+  it('rejects an unknown policy at spawn', () => {
+    expect(() => new CursorAdapter().spawn({ cwd: '/work', policy: 'yolo' }))
+      .toThrow("unknown policy 'yolo'");
+  });
+
+  it('passes headless, model, policy, resume, and prompt with the -- guard and no stdin', async () => {
+    const command = executable(`
+const detail = JSON.stringify({ argv: process.argv.slice(2), cwd: process.cwd() });
+console.log(JSON.stringify({type:'system',subtype:'init',session_id:'22222222-2222-4222-8222-222222222222',model:'cursor-test'}));
+console.log(JSON.stringify({type:'assistant',message:{role:'assistant',content:[{type:'text',text:detail}]},timestamp_ms:1}));
+console.log(JSON.stringify({type:'result',subtype:'success',is_error:false,result:detail,session_id:'22222222-2222-4222-8222-222222222222',usage:{inputTokens:1,outputTokens:1}}));
+`);
+    const adapter = new CursorAdapter(command);
+    const cwd = mkdtempSync(join(tmpdir(), 'codor-cursor-cwd-'));
+    dirs.push(cwd);
+    const session = adapter.attach('22222222-2222-4222-8222-222222222222');
+    session.cwd = cwd;
+    session.model = 'cursor-test';
+    session.policy = 'read-only';
+    const events: WireEvent[] = [];
+    for await (const event of adapter.deliver(session, 'PONG')) events.push(event);
+    const done = events.at(-1) as Extract<WireEvent, { type: 'run.completed' }>;
+    expect(done.type).toBe('run.completed');
+    const detail = JSON.parse(done.final_text!);
+    expect(detail).toEqual({
+      argv: [
+        '-p', '--output-format', 'stream-json', '--stream-partial-output', '--trust',
+        '--model', 'cursor-test',
+        '--mode', 'plan',
+        '--resume', '22222222-2222-4222-8222-222222222222',
+        '--', 'PONG',
+      ],
+      cwd: realpathSync(cwd),
+    });
+    expect(session.session_ref).toBe('22222222-2222-4222-8222-222222222222');
+  });
+
+  it('turns missing commands and nonzero exits into failed runs', async () => {
+    expect((await collect(new CursorAdapter('/definitely/missing/cursor-agent'))).at(-1))
+      .toMatchObject({ type: 'run.completed', status: 'failed' });
+    const command = executable("process.stderr.write('native failure\\n'); process.exit(7);\n");
+    expect((await collect(new CursorAdapter(command))).at(-1)).toMatchObject({
+      type: 'run.completed',
+      status: 'failed',
+      final_text: 'native failure',
+    });
+  });
+
+  it('does not enumerate the session store headlessly', () => {
+    expect(new CursorAdapter().discoverSessions()).toEqual([]);
+  });
+
+  it('rejects interaction responses because ask and runtime approvals are false', async () => {
+    await expect(new CursorAdapter().respondInteraction()).rejects.toThrow(
+      'no interaction response channel',
+    );
+  });
+});
+
+// harn:assume adapter-children-inherit-session-env ref=cursor-env-regression
+describe('member environment inheritance', () => {
+  it('merges session values over the inherited process environment', async () => {
+    const command = executable(`
+const detail = JSON.stringify({home:process.env.HOME,path:process.env.PATH,member:process.env.CODOR_TEST_SESSION_ENV});
+console.log(JSON.stringify({type:'system',subtype:'init',session_id:'22222222-2222-4222-8222-222222222222',model:'cursor-test'}));
+console.log(JSON.stringify({type:'assistant',message:{role:'assistant',content:[{type:'text',text:detail}]},timestamp_ms:1}));
+console.log(JSON.stringify({type:'result',subtype:'success',is_error:false,result:detail,session_id:'22222222-2222-4222-8222-222222222222',usage:{inputTokens:1,outputTokens:1}}));
+`);
+    const adapter = new CursorAdapter(command);
+    const session = adapter.spawn({ cwd: process.cwd() });
+    session.env = { HOME: '/codor/session-home', CODOR_TEST_SESSION_ENV: 'member-value' };
+    const events: WireEvent[] = [];
+    for await (const event of adapter.deliver(session, 'hello')) events.push(event);
+    const done = events.at(-1) as Extract<WireEvent, { type: 'run.completed' }>;
+
+    expect(adapter.capabilities.live_inbox).toBe(false);
+    expect(JSON.parse(done.final_text!)).toEqual({
+      home: '/codor/session-home', path: process.env.PATH, member: 'member-value',
+    });
+  });
+});
+// harn:end adapter-children-inherit-session-env

--- a/packages/adapters/cursor/src/adapter.ts
+++ b/packages/adapters/cursor/src/adapter.ts
@@ -1,0 +1,198 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+
+import type {
+  AdapterTurnHooks,
+  HarnessAdapter,
+  Session,
+  SessionRef,
+  SpawnOpts,
+  WireEvent,
+} from '@codor/protocol';
+import { PolicySchema } from '@codor/protocol';
+
+/**
+ * What each canonical policy becomes for `cursor-agent` in headless mode.
+ * read-only -> plan mode (no edits); workspace-write -> auto-run with the OS
+ * sandbox confining shell/filesystem to the workspace; full-access -> auto-run
+ * with the sandbox off. All three are distinct here.
+ */
+const POLICY_NATIVE = {
+  'read-only': 'plan',
+  'workspace-write': 'force+sandbox',
+  'full-access': 'yolo',
+} as const;
+
+function assertPolicy(policy: string | undefined): void {
+  if (policy === undefined) return;
+  if (!PolicySchema.safeParse(policy).success) {
+    throw new Error(`unknown policy '${policy}'; valid policies: ${PolicySchema.options.join(', ')}`);
+  }
+}
+
+function policyArgs(policy: string | undefined): string[] {
+  if (policy === undefined) return [];
+  assertPolicy(policy);
+  switch (policy) {
+    case 'read-only':
+      return ['--mode', 'plan'];
+    case 'workspace-write':
+      return ['--force', '--sandbox', 'enabled'];
+    case 'full-access':
+      return ['--force', '--sandbox', 'disabled'];
+    default:
+      return [];
+  }
+}
+
+// harn:assume canonical-spawn-controls-enforced ref=cursor-spawn-control-mapping
+export function cursorArgs(session: Session, payload: string): string[] {
+  if (session.thinking !== undefined) {
+    throw new Error("adapter 'cursor' does not support thinking levels");
+  }
+  const args = ['-p', '--output-format', 'stream-json', '--stream-partial-output', '--trust'];
+  if (session.model !== undefined) args.push('--model', session.model);
+  args.push(...policyArgs(session.policy));
+  if (session.session_ref !== undefined) args.push('--resume', session.session_ref);
+  // `--` guards payloads that begin with a dash from being parsed as flags.
+  args.push('--', payload);
+  return args;
+}
+
+/** Direct `cursor-agent` headless CLI driver. Mirrors the gemini adapter. */
+export class CursorAdapter implements HarnessAdapter {
+  readonly id = 'cursor';
+  readonly capabilities = {
+    resume: true,
+    // `cursor-agent ls` requires a TTY (Ink raw mode), so sessions cannot be
+    // enumerated headlessly. Codor still resumes via the session_ref it persists.
+    discover: false,
+    interactiveAttach: false,
+    ask: false,
+    approvals: 'spawn-time',
+    extensions: false,
+    thinking: false,
+    live_inbox: false,
+    policies: POLICY_NATIVE,
+  } as const;
+
+  private readonly children = new WeakMap<Session, ChildProcess>();
+
+  constructor(private readonly command = 'cursor-agent') {}
+
+  spawn(opts: SpawnOpts): Session {
+    assertPolicy(opts.policy);
+    if (opts.thinking !== undefined) {
+      throw new Error("adapter 'cursor' does not support thinking levels");
+    }
+    return {
+      harness: this.id,
+      cwd: opts.cwd,
+      model: opts.model,
+      policy: opts.policy,
+    };
+  }
+  // harn:end canonical-spawn-controls-enforced
+
+  attach(session_ref: SessionRef): Session {
+    return { harness: this.id, session_ref, cwd: process.cwd() };
+  }
+
+  async *deliver(
+    session: Session,
+    payload: string,
+    hooks: AdapterTurnHooks = {},
+  ): AsyncIterable<WireEvent> {
+    const { createTurnTranslator } = await import('./translate.js');
+    const args = cursorArgs(session, payload);
+
+    const child = spawn(this.command, args, {
+      cwd: session.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: true,
+      env: { ...process.env, ...session.env },
+    });
+    this.children.set(session, child);
+
+    let stderr = '';
+    child.stderr!.setEncoding('utf8');
+    child.stderr!.on('data', (chunk: string) => {
+      stderr = `${stderr}${chunk}`.slice(-8192);
+    });
+    let childError: Error | undefined;
+    const spawned = new Promise<void>((resolve, reject) => {
+      child.once('spawn', resolve);
+      child.once('error', (error) => {
+        childError = error;
+        reject(error);
+      });
+    });
+    const closed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+      (resolve) => child.once('close', (code, signal) => resolve({ code, signal })),
+    );
+
+    const translator = createTurnTranslator();
+    let reportedSessionRef: string | undefined;
+    const reportSessionRef = (): void => {
+      const discovered = translator.sessionId();
+      if (discovered === undefined || discovered === reportedSessionRef) return;
+      session.session_ref = discovered;
+      reportedSessionRef = discovered;
+      hooks.onSessionRef?.(discovered);
+    };
+
+    try {
+      try {
+        await spawned;
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        yield* translator.end({ status: 'failed', final_text: detail });
+        return;
+      }
+      hooks.onStarted?.({ pid: child.pid, process_group_id: child.pid });
+
+      const lines = createInterface({ input: child.stdout! });
+      for await (const line of lines) {
+        for (const event of translator.push(line)) {
+          reportSessionRef();
+          yield event;
+        }
+        reportSessionRef();
+      }
+      const exit = await closed;
+      const failed = childError !== undefined || (exit.code !== null && exit.code !== 0);
+      const detail = stderr.trim() || childError?.message;
+      yield* translator.end({
+        status: failed ? 'failed' : 'interrupted',
+        ...(detail !== undefined && detail !== '' && { final_text: detail }),
+      });
+    } finally {
+      this.children.delete(session);
+      if (child.exitCode === null && child.signalCode === null) this.signal(child, 'SIGKILL');
+    }
+  }
+
+  interrupt(session: Session): void {
+    const child = this.children.get(session);
+    if (child) this.signal(child, 'SIGINT');
+  }
+
+  private signal(child: ChildProcess, signal: NodeJS.Signals): void {
+    if (child.pid === undefined) return;
+    try {
+      process.kill(-child.pid, signal);
+    } catch {
+      child.kill(signal);
+    }
+  }
+
+  respondInteraction(): Promise<void> {
+    return Promise.reject(
+      new Error('cursor headless stream-json exposes no interaction response channel'),
+    );
+  }
+
+  discoverSessions(): SessionRef[] {
+    return [];
+  }
+}

--- a/packages/adapters/cursor/src/fixtures.spec.ts
+++ b/packages/adapters/cursor/src/fixtures.spec.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+type CursorEvent = {
+  type: string;
+  subtype?: string;
+  session_id?: string;
+  is_error?: boolean;
+  result?: string;
+  timestamp_ms?: number;
+  message?: { role?: string; content?: Array<{ text?: string }> };
+  usage?: Record<string, unknown>;
+};
+
+function events(name: string): CursorEvent[] {
+  return readFileSync(new URL(`../fixtures/${name}`, import.meta.url), 'utf8')
+    .split('\n')
+    .filter((line) => line.trim() !== '')
+    .map((line) => JSON.parse(line) as CursorEvent);
+}
+
+describe('SYNTHETIC documented-format cursor fixtures', () => {
+  it('are prominently marked as synthetic', () => {
+    const notice = readFileSync(new URL('../fixtures/SYNTHETIC.md', import.meta.url), 'utf8');
+    expect(notice).toContain('SYNTHETIC fixtures');
+    expect(notice).toContain('not live');
+  });
+
+  it('pins init UUID, streaming assistant deltas, and token-only success usage', () => {
+    const fixture = events('synthetic-success.jsonl');
+    expect(fixture[0]).toMatchObject({
+      type: 'system',
+      subtype: 'init',
+      session_id: '11111111-1111-4111-8111-111111111111',
+    });
+    // Only the delta events carry timestamp_ms; the cumulative echo does not.
+    expect(
+      fixture
+        .filter((event) => event.type === 'assistant' && event.timestamp_ms !== undefined)
+        .map((event) => event.message?.content?.[0]?.text),
+    ).toEqual(['PO', 'NG']);
+    expect(fixture.at(-1)).toMatchObject({
+      type: 'result',
+      subtype: 'success',
+      usage: { inputTokens: 12, outputTokens: 2 },
+    });
+  });
+
+  it('pins an errored terminal result', () => {
+    const fixture = events('synthetic-failure.jsonl');
+    expect(fixture.map((event) => event.type)).toEqual(['system', 'result']);
+    expect(fixture.at(-1)).toMatchObject({ type: 'result', is_error: true });
+  });
+});

--- a/packages/adapters/cursor/src/index.spec.ts
+++ b/packages/adapters/cursor/src/index.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { CursorAdapter } from './index.js';
+
+describe('@codor/adapter-cursor barrel', () => {
+  it('exposes only demonstrated capabilities', () => {
+    const adapter = new CursorAdapter();
+    expect(adapter.id).toBe('cursor');
+    expect(adapter.capabilities).toEqual({
+      resume: true,
+      discover: false,
+      interactiveAttach: false,
+      ask: false,
+      approvals: 'spawn-time',
+      extensions: false,
+      thinking: false,
+      live_inbox: false,
+      policies: {
+        'read-only': 'plan',
+        'workspace-write': 'force+sandbox',
+        'full-access': 'yolo',
+      },
+    });
+  });
+});

--- a/packages/adapters/cursor/src/index.ts
+++ b/packages/adapters/cursor/src/index.ts
@@ -1,0 +1,10 @@
+import { CursorAdapter } from './adapter.js';
+
+export { CursorAdapter, cursorArgs } from './adapter.js';
+export { createTurnTranslator } from './translate.js';
+export type { TurnTranslator } from './translate.js';
+
+/** Factory for the `--adapter cursor=<module>` external-registration path. */
+export function createAdapter(_config: { id: string }): CursorAdapter {
+  return new CursorAdapter();
+}

--- a/packages/adapters/cursor/src/translate.spec.ts
+++ b/packages/adapters/cursor/src/translate.spec.ts
@@ -61,6 +61,27 @@ describe('cursor stream-json translation', () => {
     });
   });
 
+  it('uses streamed text for final_text so a normalized result echo cannot double the reply', () => {
+    const translator = createTurnTranslator();
+    translator.push('{"type":"assistant","timestamp_ms":1,"message":{"content":[{"type":"text","text":"Fix applied."}]}}');
+    // cursor's terminal `result` echo is whitespace-normalized (here, a leading
+    // newline). Forwarding it as final_text would defeat codor's residual de-dupe
+    // (neither prefix nor suffix of the streamed prose) and re-append the whole
+    // reply, producing the "Fix applied.\nFix applied." doubling seen in rooms.
+    const done = translator.push(
+      '{"type":"result","subtype":"success","is_error":false,"result":"\\nFix applied."}',
+    );
+    expect(done).toEqual([{ type: 'run.completed', status: 'completed', final_text: 'Fix applied.' }]);
+  });
+
+  it('falls back to the result string when nothing streamed', () => {
+    const translator = createTurnTranslator();
+    const done = translator.push(
+      '{"type":"result","subtype":"success","is_error":false,"result":"Done."}',
+    );
+    expect(done).toEqual([{ type: 'run.completed', status: 'completed', final_text: 'Done.' }]);
+  });
+
   it('maps an errored result to a failed run', () => {
     expect(replay('synthetic-failure.jsonl').events.at(-1)).toEqual({
       type: 'run.completed',

--- a/packages/adapters/cursor/src/translate.spec.ts
+++ b/packages/adapters/cursor/src/translate.spec.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs';
+
+import { parseRunItemPayload, type WireEvent } from '@codor/protocol';
+import { describe, expect, it } from 'vitest';
+
+import { createTurnTranslator } from './translate.js';
+
+function replay(name: string): { events: WireEvent[]; sessionId: string | undefined } {
+  const translator = createTurnTranslator();
+  const events = readFileSync(new URL(`../fixtures/${name}`, import.meta.url), 'utf8')
+    .split('\n')
+    .flatMap((line) => translator.push(line));
+  events.push(...translator.end());
+  for (const event of events) {
+    if (event.type === 'run.item') {
+      expect(parseRunItemPayload(event.item_type, event.payload).success).toBe(true);
+    }
+  }
+  return { events, sessionId: translator.sessionId() };
+}
+
+function textDeltas(events: WireEvent[]): string[] {
+  return events
+    .filter((event): event is Extract<WireEvent, { type: 'run.item' }> =>
+      event.type === 'run.item' && event.item_type === 'text_delta')
+    .map((event) => (event.payload as { text: string }).text);
+}
+
+describe('cursor stream-json translation', () => {
+  it('translates the documented success vocabulary and token-only usage', () => {
+    const replayed = replay('synthetic-success.jsonl');
+    expect(replayed.sessionId).toBe('11111111-1111-4111-8111-111111111111');
+
+    // Streaming deltas only — the trailing cumulative assistant echo is skipped.
+    expect(textDeltas(replayed.events)).toEqual(['PO', 'NG']);
+
+    expect(replayed.events).toContainEqual({
+      type: 'run.item',
+      item_type: 'reasoning_summary',
+      payload: { text: 'Reading the file.' },
+    });
+
+    expect(replayed.events).toContainEqual({
+      type: 'run.item',
+      item_type: 'tool_call',
+      payload: {
+        call_id: 'read-1',
+        tool: 'read',
+        title: 'README.md',
+        detail: 'README.md',
+        input: { path: 'README.md' },
+      },
+    });
+
+    const done = replayed.events.at(-1) as Extract<WireEvent, { type: 'run.completed' }>;
+    expect(done).toEqual({
+      type: 'run.completed',
+      status: 'completed',
+      final_text: 'PONG',
+      usage: { input_tokens: 12, output_tokens: 2 },
+    });
+  });
+
+  it('maps an errored result to a failed run', () => {
+    expect(replay('synthetic-failure.jsonl').events.at(-1)).toEqual({
+      type: 'run.completed',
+      status: 'failed',
+      final_text: 'Authentication required',
+      usage: { input_tokens: 0, output_tokens: 0 },
+    });
+  });
+
+  it('ignores malformed and unknown lines and treats unterminated EOF as interrupted', () => {
+    const translator = createTurnTranslator();
+    expect(translator.push('not-json')).toEqual([]);
+    expect(translator.push('{"type":"future"}')).toEqual([]);
+    expect(translator.end()).toEqual([{ type: 'run.completed', status: 'interrupted' }]);
+  });
+});

--- a/packages/adapters/cursor/src/translate.ts
+++ b/packages/adapters/cursor/src/translate.ts
@@ -1,0 +1,182 @@
+import type { WireEvent } from '@codor/protocol';
+
+/** One line of `cursor-agent --output-format stream-json` output. */
+interface CursorEvent {
+  type?: string;
+  subtype?: string;
+  session_id?: string;
+  timestamp_ms?: number;
+  is_error?: boolean;
+  result?: string;
+  text?: string;
+  message?: { role?: string; content?: Array<{ type?: string; text?: string }> };
+  call_id?: string;
+  tool_call?: Record<string, { args?: unknown; result?: unknown }>;
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+  };
+}
+
+export interface TurnTranslator {
+  push(line: string): WireEvent[];
+  end(fallback?: { status: 'failed' | 'interrupted'; final_text?: string }): WireEvent[];
+  sessionId(): string | undefined;
+}
+
+const MAX_OUTPUT = 256 * 1024;
+
+function boundedOutput(value: string | undefined): string | undefined {
+  if (value === undefined || Buffer.byteLength(value) <= MAX_OUTPUT) return value;
+  const marker = '\n[output truncated at 256 KiB]';
+  const markerBytes = Buffer.byteLength(marker);
+  let prefix = Buffer.from(value).subarray(0, MAX_OUTPUT - markerBytes).toString('utf8');
+  while (Buffer.byteLength(prefix) + markerBytes > MAX_OUTPUT) prefix = prefix.slice(0, -1);
+  return `${prefix}${marker}`;
+}
+
+function assistantText(event: CursorEvent): string {
+  return (event.message?.content ?? [])
+    .filter((part) => part.type === 'text' || part.type === undefined)
+    .map((part) => part.text ?? '')
+    .join('');
+}
+
+/** `{ shellToolCall: {...} }` -> ['shell', innerObject]. */
+function toolEntry(event: CursorEvent): { name: string; inner: { args?: unknown; result?: unknown } } {
+  const map = event.tool_call ?? {};
+  const key = Object.keys(map)[0];
+  if (key === undefined) return { name: 'tool', inner: {} };
+  return { name: key.replace(/ToolCall$/, '') || 'tool', inner: map[key] ?? {} };
+}
+
+/** A short, human-facing detail line for a tool call, best-effort per tool shape. */
+function toolDetail(name: string, args: unknown): string | undefined {
+  if (typeof args !== 'object' || args === null) return undefined;
+  const a = args as Record<string, unknown>;
+  const pick = (v: unknown): string | undefined => (typeof v === 'string' && v !== '' ? v : undefined);
+  return pick(a['command']) ?? pick(a['path']) ?? pick(a['description']) ?? pick(a['query']);
+}
+
+/**
+ * Translate the `cursor-agent` stream-json event vocabulary into WireEvents.
+ * Event shapes are documented in NOTES.md (captured from the live CLI).
+ */
+export function createTurnTranslator(): TurnTranslator {
+  let sessionId: string | undefined;
+  let finalText = '';
+  let terminal = false;
+
+  return {
+    sessionId: () => sessionId,
+
+    push(line: string): WireEvent[] {
+      if (line.trim() === '') return [];
+      let event: CursorEvent;
+      try {
+        event = JSON.parse(line) as CursorEvent;
+      } catch {
+        return [];
+      }
+
+      switch (event.type) {
+        case 'system':
+          if (event.subtype === 'init' && typeof event.session_id === 'string') {
+            sessionId = event.session_id;
+          }
+          return [];
+
+        case 'thinking':
+          if (event.subtype !== 'delta' || !event.text) return [];
+          return [{ type: 'run.item', item_type: 'reasoning_summary', payload: { text: event.text } }];
+
+        case 'assistant': {
+          // Streaming deltas carry timestamp_ms; the final cumulative echo does not.
+          // Emit only the deltas so text is not counted twice.
+          if (event.timestamp_ms === undefined) return [];
+          const text = assistantText(event);
+          if (text === '') return [];
+          finalText += text;
+          return [{ type: 'run.item', item_type: 'text_delta', payload: { text } }];
+        }
+
+        case 'tool_call': {
+          const { name, inner } = toolEntry(event);
+          const callId = event.call_id ?? `cursor-${name}`;
+          if (event.subtype === 'started') {
+            const detail = toolDetail(name, inner.args);
+            return [
+              {
+                type: 'run.item',
+                item_type: 'tool_call',
+                payload: {
+                  call_id: callId,
+                  tool: name,
+                  title: detail ?? name,
+                  ...(detail !== undefined && { detail }),
+                  input: inner.args ?? {},
+                },
+              },
+            ];
+          }
+          if (event.subtype === 'completed') {
+            const result = inner.result as Record<string, unknown> | undefined;
+            const ok = result === undefined || 'success' in result;
+            return [
+              {
+                type: 'run.item',
+                item_type: 'tool_result',
+                payload: {
+                  call_id: callId,
+                  status: ok ? 'ok' : 'error',
+                  output_text: boundedOutput(result === undefined ? undefined : JSON.stringify(result)),
+                  raw: event,
+                },
+              },
+            ];
+          }
+          return [];
+        }
+
+        case 'result': {
+          terminal = true;
+          const completed = event.subtype === 'success' && event.is_error !== true;
+          const text = (typeof event.result === 'string' && event.result !== '' ? event.result : finalText);
+          const usage = event.usage === undefined
+            ? undefined
+            : {
+                input_tokens: event.usage.inputTokens ?? 0,
+                output_tokens: event.usage.outputTokens ?? 0,
+              };
+          return [
+            {
+              type: 'run.completed',
+              status: completed ? 'completed' : 'failed',
+              ...(text !== '' && { final_text: text }),
+              ...(usage !== undefined && { usage }),
+            },
+          ];
+        }
+
+        default:
+          return [];
+      }
+    },
+
+    end(fallback = { status: 'interrupted' as const }): WireEvent[] {
+      if (terminal) return [];
+      terminal = true;
+      return [
+        {
+          type: 'run.completed',
+          status: fallback.status,
+          ...(fallback.final_text !== undefined || finalText !== ''
+            ? { final_text: fallback.final_text ?? finalText }
+            : {}),
+        },
+      ];
+    },
+  };
+}

--- a/packages/adapters/cursor/src/translate.ts
+++ b/packages/adapters/cursor/src/translate.ts
@@ -143,7 +143,14 @@ export function createTurnTranslator(): TurnTranslator {
         case 'result': {
           terminal = true;
           const completed = event.subtype === 'success' && event.is_error !== true;
-          const text = (typeof event.result === 'string' && event.result !== '' ? event.result : finalText);
+          // Prefer the text assembled from streamed `text_delta`s so `final_text`
+          // matches codor's journaled prose byte-for-byte. cursor's `result` is a
+          // whitespace-normalized echo (e.g. it can gain a leading newline); when it
+          // diverges from the streamed text, codor's residual de-dupe fails to match
+          // and re-appends the whole reply, doubling it. Fall back to `result` only
+          // when nothing was streamed.
+          const resultText = typeof event.result === 'string' ? event.result : '';
+          const text = finalText !== '' ? finalText : resultText;
           const usage = event.usage === undefined
             ? undefined
             : {

--- a/packages/adapters/cursor/tsconfig.json
+++ b/packages/adapters/cursor/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.spec.ts"]
+}

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -16,7 +16,7 @@ import { CryptoVault, pairingUrl } from '@codor/switchboard';
 
 import { renderTerminalQr } from './terminal-qr.js';
 
-const HARNESSES = ['claude', 'codex', 'opencode', 'gemini', 'copilot'] as const;
+const HARNESSES = ['claude', 'codex', 'opencode', 'gemini', 'copilot', 'cursor-agent'] as const;
 const LAUNCH_AGENT_LABEL = 'app.codor.switchboard';
 
 export interface SetupOverrides {

--- a/packages/switchboard/package.json
+++ b/packages/switchboard/package.json
@@ -21,6 +21,7 @@
     "@codor/adapter-claude-code": "workspace:*",
     "@codor/adapter-codex": "workspace:*",
     "@codor/adapter-copilot": "workspace:*",
+    "@codor/adapter-cursor": "workspace:*",
     "@codor/adapter-gemini": "workspace:*",
     "@codor/adapter-opencode": "workspace:*",
     "@codor/protocol": "workspace:*",

--- a/packages/switchboard/src/adapter-registry.spec.ts
+++ b/packages/switchboard/src/adapter-registry.spec.ts
@@ -22,6 +22,7 @@ describe('adapter registry spawn controls', () => {
       ['claude-code', true, ['low', 'medium', 'high', 'xhigh', 'max', 'ultracode']],
       ['codex', true, ['low', 'medium', 'high', 'xhigh', 'max', 'ultra']],
       ['copilot', false, undefined],
+      ['cursor', false, undefined],
       ['gemini', false, undefined],
       ['opencode', true, ['low', 'medium', 'high']],
     ]);

--- a/packages/switchboard/src/adapter-registry.ts
+++ b/packages/switchboard/src/adapter-registry.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from 'node:url';
 import { ClaudeCodeAdapter } from '@codor/adapter-claude-code';
 import { CodexAdapter } from '@codor/adapter-codex';
 import { CopilotAdapter } from '@codor/adapter-copilot';
+import { CursorAdapter } from '@codor/adapter-cursor';
 import { GeminiAdapter } from '@codor/adapter-gemini';
 import { OpenCodeAdapter } from '@codor/adapter-opencode';
 import {
@@ -33,6 +34,7 @@ const builtinFactories = {
   'claude-code': () => new ClaudeCodeAdapter(),
   codex: () => new CodexAdapter(),
   copilot: () => new CopilotAdapter(),
+  cursor: () => new CursorAdapter(),
   gemini: () => new GeminiAdapter(),
   opencode: () => new OpenCodeAdapter(),
 } satisfies Record<string, AdapterFactory>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,12 @@ importers:
         specifier: workspace:*
         version: link:../../protocol
 
+  packages/adapters/cursor:
+    dependencies:
+      '@codor/protocol':
+        specifier: workspace:*
+        version: link:../../protocol
+
   packages/adapters/gemini:
     dependencies:
       '@codor/protocol':
@@ -132,6 +138,9 @@ importers:
       '@codor/adapter-copilot':
         specifier: workspace:*
         version: link:../adapters/copilot
+      '@codor/adapter-cursor':
+        specifier: workspace:*
+        version: link:../adapters/cursor
       '@codor/adapter-gemini':
         specifier: workspace:*
         version: link:../adapters/gemini


### PR DESCRIPTION
## What

Adds a `cursor` built-in harness adapter that drives the [Cursor CLI](https://cursor.com/cli) (`cursor-agent`) in headless mode, so Cursor can join channels alongside Claude Code, Codex, Gemini, Copilot, and OpenCode.

`cursor-agent` is a per-turn CLI that streams `--output-format stream-json`, so the adapter mirrors the **gemini** adapter's shape (supervised subprocess + readline over stdout + a pure stream translator) rather than the persistent-runtime shape of claude-code/codex.

## Design

Invocation:
```
cursor-agent -p --output-format stream-json --stream-partial-output --trust \
  [--model <m>] [<policy flags>] [--resume <session_id>] -- <payload>
```

- **Session ref** — captured from the `system/init` line and reported via `hooks.onSessionRef`; subsequent turns pass `--resume <id>`.
- **Policy mapping** — `read-only` → `--mode plan`; `workspace-write` → `--force --sandbox enabled` (OS sandbox confines shell/fs to the workspace); `full-access` → `--force --sandbox disabled`.
- **Streaming** — `assistant` events carrying `timestamp_ms` are incremental deltas → `text_delta`; the trailing cumulative echo is skipped so text isn't doubled. `thinking` → `reasoning_summary`, `tool_call` started/completed → `tool_call`/`tool_result`, `result` → `run.completed` with usage.
- **Capabilities** — `resume:true`, `discover:false` (`cursor-agent ls` needs a TTY / Ink raw mode, so the session store can't be enumerated headlessly; codor still resumes from its own persisted `session_ref`), `ask:false`, `approvals:'spawn-time'`, `thinking:false` (reasoning effort is expressed inside the `--model` string).

The captured `stream-json` event vocabulary and sources are documented in `packages/adapters/cursor/NOTES.md`.

## Changes

- `packages/adapters/cursor/` — adapter, translator, `NOTES.md`, and specs (`translate`/`adapter`/`index`/`fixtures`) mirroring the gemini suite, plus SYNTHETIC fixtures.
- Register `cursor` in the switchboard adapter registry (`adapter-registry.ts` + `package.json`); add the `['cursor', false, undefined]` row to `adapter-registry.spec.ts`.
- Probe `cursor-agent` in `codor setup` PATH detection (`setup.ts` `HARNESSES`).
- List Cursor in the README supported-agents prerequisites.

## Testing

- New package suite passes: `pnpm --filter @codor/adapter-cursor test` → **14/14** (policy→flag mapping, headless argv incl. the `--` guard, session-ref reporting, env inheritance, failed-run handling, fixture replay).
- `pnpm --filter @codor/switchboard exec vitest run adapter-registry.spec.ts hot-swap.integration.spec.ts` → **19/19**; `codor setup` snapshot test still green.
- Verified live end-to-end against `cursor-agent 2026.07.16` (subscription auth): single turn, token usage capture, and stateful multi-turn `--resume`.

Behavioral reference only — mirrors the gemini adapter's patterns per the approach in `docs/ARCHITECTURE.md`; no third-party adapter code copied.
