### PR TITLE
Stop agents appending <ACK_OK> to substantive replies

### DIFF
--- a/packages/switchboard/src/collaboration.spec.ts
+++ b/packages/switchboard/src/collaboration.spec.ts
@@ -105,8 +105,9 @@ describe('group round payload composition', () => {
       'update, question, or answer. An @mention in your final response starts another paid group ' +
       "round, so use one only when you genuinely intend to invoke that member; write the member's " +
       'plain name without @ when merely discussing them. If every peer you are waiting on finishes ' +
-      'without an interim reply, Codor ends the wait automatically. If no substantive onward ' +
-      'response is needed, respond with exactly <ACK_OK>.]\n',
+      'without an interim reply, Codor ends the wait automatically. Use <ACK_OK> as your entire ' +
+      'onward response only when no action and no answer are needed; never append it after doing ' +
+      'work or as a sign-off.]\n',
     );
     expect(payload).not.toContain('\n<ACK_OK>\n');
   });

--- a/packages/switchboard/src/collaboration.ts
+++ b/packages/switchboard/src/collaboration.ts
@@ -119,8 +119,9 @@ const GROUP_ROUTING_INSTRUCTION =
   'update, question, or answer. An @mention in your final response starts another paid group ' +
   "round, so use one only when you genuinely intend to invoke that member; write the member's " +
   'plain name without @ when merely discussing them. If every peer you are waiting on finishes ' +
-  'without an interim reply, Codor ends the wait automatically. If no substantive onward ' +
-  'response is needed, respond with exactly <ACK_OK>.]';
+  'without an interim reply, Codor ends the wait automatically. Use <ACK_OK> as your entire ' +
+  'onward response only when no action and no answer are needed; never append it after doing ' +
+  'work or as a sign-off.]';
 // harn:end group-routing-briefing-names-cost-and-wait-outcome
 
 export function composeGroupRoundPayload(ctx: GroupRoundPayloadContext, you: string): string {

--- a/packages/switchboard/src/router.spec.ts
+++ b/packages/switchboard/src/router.spec.ts
@@ -462,8 +462,9 @@ describe('delivery payload template (byte-exact goldens)', () => {
         '#N. Cite ledger notes as [[name]]. Use codor post only for interim updates and --wait ' +
         'when a direct reply is required; on timeout, check codor status and renew while the peer ' +
         'is active. During long tasks, check codor inbox --new. Use codor search --runs before ' +
-        'asking about unseen referenced context. If no substantive reply is needed, respond with ' +
-        'exactly <ACK_OK>.]\n',
+        'asking about unseen referenced context. Use <ACK_OK> as your entire reply only when a ' +
+        'message needs no action and no answer; never append it after doing work or as a ' +
+        'sign-off.]\n',
     );
   });
 

--- a/packages/switchboard/src/router.ts
+++ b/packages/switchboard/src/router.ts
@@ -226,7 +226,8 @@ export function composeDeliveryBriefing(ctx: DeliveryBriefingContext): string {
       `on timeout, check codor status and renew while the peer is active. ` +
       `${ctx.conventions.liveInbox ? '' : 'During long tasks, check codor inbox --new. '}` +
       `Use codor search --runs before asking about unseen referenced context. ` +
-      `If no substantive reply is needed, respond with exactly <ACK_OK>.]\n`;
+      `Use <ACK_OK> as your entire reply only when a message needs no action and no answer; ` +
+      `never append it after doing work or as a sign-off.]\n`;
     // harn:end agent-briefings-distinguish-invocation-from-discussion
     // harn:end collaboration-briefing-is-capability-aware
   }


### PR DESCRIPTION
## Problem

The roster briefing (`router.ts`) and group-round briefing (`collaboration.ts`) both end with:

> If no substantive reply is needed, respond with exactly `<ACK_OK>`.

In multi-agent rooms I saw models (codex in particular) read this as license to finish a **substantive** turn and then append a bare `<ACK_OK>` as a sign-off, or emit it as the final text of a work-heavy turn. Because the ack-muting only fires when a run's aggregate `final_text` trims *exactly* to the marker (per `acknowledgement-marker-protocol`), those trailing markers are **not** muted and render as noisy `<ACK_OK>` bubbles next to real output.

## Change

Reword both briefings so the marker is unambiguously the agent's **entire** reply — used only when no action and no answer are needed — and never appended after doing work or as a sign-off. No behavior or detection change; only the instruction wording. Spec assertions updated to match.

## Test

```
npx vitest run src/router.spec.ts src/collaboration.spec.ts  → 90 passed
```