### PR TITLE
feat(switchboard): estimate USD cost for tokens-only harnesses

### DIFF
--- a/packages/switchboard/src/daemon.spec.ts
+++ b/packages/switchboard/src/daemon.spec.ts
@@ -1455,6 +1455,27 @@ describe('meters, opt-in brakes, and stall flags', () => {
       .toMatchObject({ cost_usd: 0, uncosted_tokens: 15 });
   });
 
+  it('estimates cost for a tokens-only member whose model has a known price', async () => {
+    const alpha = spawnAgent('alpha');
+    daemon.spawnMember('eng', { harness: 'fake', handle: 'codexy', cwd: testCwd(), model: 'gpt-5.5' });
+    const codexy = daemon.store.getMemberByHandle('eng', 'codexy')!;
+    // gpt-5.5: $1.25/Mtok in, $10/Mtok out -> 1_000_000*1.25e-6 + 200_000*1e-5 = 1.25 + 2.00
+    fake.enqueue({
+      kind: 'complete',
+      final_text: '@richard priced tokens-only completion',
+      usage: { input_tokens: 1_000_000, output_tokens: 200_000 },
+    });
+    daemon.postHumanMessage('eng', '@codexy spend once');
+    await daemon.settle();
+    const spend = daemon.memberDetails('eng').find((detail) => detail.member.id === codexy.id)!.spend;
+    expect(spend.cost_usd).toBe(0);
+    expect(spend.uncosted_tokens).toBe(0); // priced -> no longer uncosted
+    expect(spend.estimated_cost_usd).toBeCloseTo(3.25, 6);
+    // A member with no priced model still reports nothing spent.
+    expect(daemon.memberDetails('eng').find((detail) => detail.member.id === alpha.id)!.spend)
+      .toMatchObject({ estimated_cost_usd: 0, uncosted_tokens: 0 });
+  });
+
   it('rechecks spend before a queued agent hop starts and releases it exactly once', async () => {
     const gamma = spawnAgent('gamma');
     const alpha = spawnAgent('alpha');

--- a/packages/switchboard/src/daemon.ts
+++ b/packages/switchboard/src/daemon.ts
@@ -49,6 +49,7 @@ import { ContinuationWriter, projectContinuationOutputs } from './continuation.j
 import type { LedgerGraph, LedgerManager } from './ledger/watch.js';
 import type { LedgerNote, LedgerWrite } from './ledger/vault.js';
 import type { HumanPushKind, HumanPushNotifier } from './push/producer.js';
+import { estimateCostUsd } from './pricing.js';
 import { redactValue } from './redact.js';
 import {
   RemoteAttemptAmbiguousError,
@@ -201,6 +202,7 @@ export interface MemberDetails {
     input_tokens: number;
     output_tokens: number;
     cost_usd: number;
+    estimated_cost_usd: number; // tokens-only harnesses priced from the model table
     uncosted_tokens: number;
   };
 }
@@ -1057,18 +1059,36 @@ export class Daemon {
           state: 'queued',
         }).length,
         spend: runs.reduce(
-          (total, message) => ({
-            turns: total.turns + 1,
-            input_tokens: total.input_tokens + (message.run?.usage?.input_tokens ?? 0),
-            output_tokens: total.output_tokens + (message.run?.usage?.output_tokens ?? 0),
-            cost_usd: total.cost_usd + (message.run?.usage?.cost_usd ?? 0),
-            uncosted_tokens:
-              total.uncosted_tokens +
-              (message.run?.usage !== undefined && message.run.usage.cost_usd === undefined
-                ? message.run.usage.input_tokens + message.run.usage.output_tokens
-                : 0),
-          }),
-          { turns: 0, input_tokens: 0, output_tokens: 0, cost_usd: 0, uncosted_tokens: 0 },
+          (total, message) => {
+            const usage = message.run?.usage;
+            // Self-reported cost wins. Otherwise estimate from tokens when the
+            // member's model has a known price; an unpriced model stays uncosted
+            // rather than being guessed.
+            const estimate =
+              usage !== undefined && usage.cost_usd === undefined
+                ? estimateCostUsd(member.model, usage)
+                : undefined;
+            return {
+              turns: total.turns + 1,
+              input_tokens: total.input_tokens + (usage?.input_tokens ?? 0),
+              output_tokens: total.output_tokens + (usage?.output_tokens ?? 0),
+              cost_usd: total.cost_usd + (usage?.cost_usd ?? 0),
+              estimated_cost_usd: total.estimated_cost_usd + (estimate ?? 0),
+              uncosted_tokens:
+                total.uncosted_tokens +
+                (usage !== undefined && usage.cost_usd === undefined && estimate === undefined
+                  ? usage.input_tokens + usage.output_tokens
+                  : 0),
+            };
+          },
+          {
+            turns: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            cost_usd: 0,
+            estimated_cost_usd: 0,
+            uncosted_tokens: 0,
+          },
         ),
       };
     });

--- a/packages/switchboard/src/pricing.spec.ts
+++ b/packages/switchboard/src/pricing.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { estimateCostUsd, priceForModel } from './pricing.js';
+
+describe('estimateCostUsd', () => {
+  it('prices a known tokens-only model from input+output rates', () => {
+    // gpt-5.5: $1.25/Mtok in, $10/Mtok out.
+    // 1_000_000 in + 100_000 out = 1.25 + 1.00 = 2.25
+    expect(estimateCostUsd('gpt-5.5', { input_tokens: 1_000_000, output_tokens: 100_000 })).toBeCloseTo(
+      2.25,
+      6,
+    );
+  });
+
+  it('is case-insensitive on the model alias', () => {
+    expect(estimateCostUsd('GPT-5.5', { input_tokens: 1_000_000, output_tokens: 0 })).toBeCloseTo(
+      1.25,
+      6,
+    );
+  });
+
+  it('returns undefined for an unknown/unpriced model so usage stays uncosted', () => {
+    expect(estimateCostUsd('auto', { input_tokens: 1000, output_tokens: 1000 })).toBeUndefined();
+    expect(estimateCostUsd(undefined, { input_tokens: 1000, output_tokens: 1000 })).toBeUndefined();
+  });
+
+  it('estimates zero for zero tokens on a priced model', () => {
+    expect(estimateCostUsd('gemini-2.5-pro', { input_tokens: 0, output_tokens: 0 })).toBe(0);
+  });
+
+  it('exposes the rate table via priceForModel', () => {
+    expect(priceForModel('gemini-3-pro-preview')).toEqual({ inputPerMTok: 2, outputPerMTok: 12 });
+    expect(priceForModel('nope')).toBeUndefined();
+  });
+});

--- a/packages/switchboard/src/pricing.ts
+++ b/packages/switchboard/src/pricing.ts
@@ -1,0 +1,60 @@
+// harn:assume tokens-only-harness-cost-is-estimated-from-a-price-table ref=estimated-cost-pricing
+/**
+ * USD cost estimates for harnesses that report token counts but no dollar cost
+ * (codex, gemini, ...). Claude Code and opencode self-report exact cost and
+ * never consult this table — their `usage.cost_usd` is authoritative.
+ *
+ * The GPT-5.6 and gemini rows are the providers' published per-token rates
+ * (OpenAI GPT-5.6 sheet; Google's Gemini API pricing page, verified 2026-07).
+ * They use each model's base tier — the ≤200k-context rate and the
+ * text/image/video input rate — so a very long prompt or audio input is
+ * under-estimated; this is a spend gauge, not billing. Estimates are always
+ * surfaced flagged as "est." so an operator never mistakes one for a
+ * self-reported charge, and an unknown model stays in the "uncosted tokens"
+ * bucket rather than guessed. Edit the table to match your contract pricing.
+ *
+ * Rates are USD per 1,000,000 tokens.
+ */
+export interface ModelPrice {
+  inputPerMTok: number;
+  outputPerMTok: number;
+}
+
+const MILLION = 1_000_000;
+
+/** Keyed by the model alias carried on `Member.model` (adapter model catalogs). */
+export const MODEL_PRICES: Record<string, ModelPrice> = {
+  // codex (OpenAI) — GPT-5.6 published rates (GA 2026-07-09); luna→terra→sol is
+  // the cost-optimized→balanced→flagship ladder.
+  'gpt-5.6-luna': { inputPerMTok: 1, outputPerMTok: 6 }, // cost-optimized tier
+  'gpt-5.6-terra': { inputPerMTok: 2.5, outputPerMTok: 15 }, // balanced tier
+  'gpt-5.6-sol': { inputPerMTok: 5, outputPerMTok: 30 }, // flagship tier
+  'gpt-5.5': { inputPerMTok: 1.25, outputPerMTok: 10 }, // prior-gen flagship
+  // gemini — Google's published rates; keys match the adapter's model catalog.
+  'gemini-3-pro-preview': { inputPerMTok: 2, outputPerMTok: 12 }, // Gemini 3.x Pro Preview, ≤200k tier
+  'gemini-3-flash-preview': { inputPerMTok: 0.5, outputPerMTok: 3 },
+  'gemini-2.5-pro': { inputPerMTok: 1.25, outputPerMTok: 10 }, // ≤200k tier
+  'gemini-2.5-flash': { inputPerMTok: 0.3, outputPerMTok: 2.5 },
+};
+
+export function priceForModel(model: string | undefined): ModelPrice | undefined {
+  if (model === undefined) return undefined;
+  return MODEL_PRICES[model] ?? MODEL_PRICES[model.toLowerCase()];
+}
+
+/**
+ * Estimate USD cost from token counts for a tokens-only harness. Returns
+ * `undefined` when the model is unknown/unpriced, so callers keep that usage
+ * in the uncosted bucket instead of reporting a fabricated dollar figure.
+ */
+export function estimateCostUsd(
+  model: string | undefined,
+  usage: { input_tokens: number; output_tokens: number },
+): number | undefined {
+  const price = priceForModel(model);
+  if (price === undefined) return undefined;
+  return (
+    (usage.input_tokens * price.inputPerMTok + usage.output_tokens * price.outputPerMTok) / MILLION
+  );
+}
+// harn:end tokens-only-harness-cost-is-estimated-from-a-price-table

--- a/packages/web-next/src/room/ContextPanel.tsx
+++ b/packages/web-next/src/room/ContextPanel.tsx
@@ -219,6 +219,14 @@ function MemberCard(props: {
 
   const spend = detail?.spend;
   const tokens = spend !== undefined ? spend.input_tokens + spend.output_tokens : undefined;
+  // Self-reported cost wins; a tokens-only harness shows its price-table estimate
+  // flagged "est." so it is never mistaken for a real charge.
+  const spendLabel =
+    spend === undefined
+      ? undefined
+      : spend.cost_usd > 0 || (spend.estimated_cost_usd ?? 0) === 0
+        ? usd(spend.cost_usd)
+        : `~${usd(spend.estimated_cost_usd ?? 0)} est.`;
 
   // Compaction is a round trip to the engine with no run to watch, so the card
   // owns the only evidence the operator has that their click did anything. It
@@ -350,7 +358,7 @@ function MemberCard(props: {
       {member.kind === 'agent' && (spend !== undefined || (detail?.queued_count ?? 0) > 0) && (
         <p className="nx-member-meter">
           {tokens !== undefined ? `${compactCount(tokens)} tokens` : ''}
-          {spend !== undefined ? ` · ${usd(spend.cost_usd)} · ${spend.turns} turns` : ''}
+          {spend !== undefined ? ` · ${spendLabel} · ${spend.turns} turns` : ''}
           {(detail?.queued_count ?? 0) > 0 ? ` · ${detail?.queued_count} queued` : ''}
         </p>
       )}

--- a/packages/web/src/api.ts
+++ b/packages/web/src/api.ts
@@ -28,6 +28,7 @@ export interface MemberDetail {
     input_tokens: number;
     output_tokens: number;
     cost_usd: number;
+    estimated_cost_usd?: number; // tokens-only harnesses priced from the model table
     uncosted_tokens?: number;
   };
 }


### PR DESCRIPTION
## What

Harnesses that report token counts but no dollar cost (codex, gemini) previously showed `$0.00` in the member meter — indistinguishable from a genuinely idle/free member. This adds a small model price table and estimates spend from tokens when the member's model has a known rate, surfaced flagged as `~$X est.` so it's never mistaken for a self-reported charge.

## How

- **`pricing.ts`** (new): `MODEL_PRICES` table + `estimateCostUsd()` / `priceForModel()`. Rows are the providers' published per-token rates (OpenAI GPT-5.6; Google's Gemini API pricing page, verified 2026-07), keyed to the adapter model catalogs. Uses each model's base tier (≤200k context, text/image/video input) — a spend gauge, not billing. Operators can edit the table for contract pricing.
- **`daemon.ts`**: spend aggregation gains an `estimated_cost_usd` bucket. Self-reported `cost_usd` still wins; an *unpriced* model stays in the existing `uncosted_tokens` bucket rather than being guessed.
- **`web/api.ts` + `ContextPanel.tsx`**: surface the estimate as `~$X est.`.

Claude Code and opencode self-report exact cost and never consult the table — their `usage.cost_usd` stays authoritative. Unknown models degrade to the pre-existing uncosted behavior, so there's no regression for self-reporting harnesses.

## Test plan

- `vitest run packages/switchboard/src/pricing.spec.ts` → 5 passed
- `vitest run packages/switchboard/src/daemon.spec.ts -t "estimates cost for a tokens-only member"` → 1 passed