### PR TITLE
Add source Tura harness adapter

### DIFF
--- a/packages/adapters/tura/fixtures/native-run.jsonl
+++ b/packages/adapters/tura/fixtures/native-run.jsonl
@@ -1,0 +1,5 @@
+{"type":"cli.started","sessionID":"ses_tura"}
+{"type":"message.part.delta","sessionID":"ses_tura","text":"PONG"}
+{"type":"command.updated","sessionID":"ses_tura","raw":{"payload":{"properties":{"commandID":"cmd_1","status":"running","command":"command_run","input":{"command_line":"pwd"}}}}}
+{"type":"command.updated","sessionID":"ses_tura","raw":{"payload":{"properties":{"commandID":"cmd_1","status":"completed","command":"command_run","output":"/work"}}}}
+{"type":"cli.completed","sessionID":"ses_tura","status":"completed","finalText":"PONG"}

--- a/packages/adapters/tura/package.json
+++ b/packages/adapters/tura/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@codor/adapter-tura",
+  "version": "0.10.2",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@codor/protocol": "workspace:*",
+    "cross-spawn": "^7.0.6"
+  },
+  "devDependencies": {
+    "@types/cross-spawn": "^6.0.6"
+  }
+}

--- a/packages/adapters/tura/src/adapter.spec.ts
+++ b/packages/adapters/tura/src/adapter.spec.ts
@@ -1,0 +1,130 @@
+import {
+  chmodSync, existsSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { WireEvent } from '@codor/protocol';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { TuraAdapter, turaArgs } from './adapter.js';
+
+const dirs: string[] = [];
+
+function executable(source: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'codor-tura-adapter-'));
+  dirs.push(dir);
+  const path = join(dir, 'fake-tura');
+  writeFileSync(path, `#!/usr/bin/env node\n${source}`);
+  chmodSync(path, 0o755);
+  return path;
+}
+
+function waitFor(path: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + 2_000;
+    const poll = (): void => {
+      if (existsSync(path)) return resolve();
+      if (Date.now() >= deadline) return reject(new Error(`timed out waiting for ${path}`));
+      setTimeout(poll, 10);
+    };
+    poll();
+  });
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('Tura subprocess and capability conformance', () => {
+  it('passes source-CLI arguments, model, resume token, cwd, and no stdin', async () => {
+    const command = executable(`
+const fs = require('node:fs');
+const detail = JSON.stringify({argv:process.argv.slice(2),cwd:process.cwd(),input:fs.readFileSync(0,'utf8'),projectRoot:process.env.TURA_PROJECT_ROOT});
+console.log(JSON.stringify({type:'cli.started',sessionID:'ses_existing'}));
+console.log(JSON.stringify({type:'cli.completed',sessionID:'ses_existing',status:'completed',finalText:detail}));
+`);
+    const adapter = new TuraAdapter(command);
+    const cwd = mkdtempSync(join(tmpdir(), 'codor-tura-cwd-'));
+    dirs.push(cwd);
+    const session = adapter.attach('ses_existing');
+    session.cwd = cwd;
+    session.model = 'openai/gpt-5.6-sol';
+    const events: WireEvent[] = [];
+    for await (const event of adapter.deliver(session, 'PONG')) events.push(event);
+    const done = events.at(-1) as Extract<WireEvent, { type: 'run.completed' }>;
+    expect(JSON.parse(done.final_text!)).toEqual({
+      argv: ['--cwd', cwd, 'run', '--output', 'ndjson', '--agent-id', 'balanced', '--session-type', 'coding', '--model', 'openai/gpt-5.6-sol', '--session', 'ses_existing', 'PONG'],
+      cwd: realpathSync(cwd),
+      input: '',
+      projectRoot: cwd,
+    });
+    expect(session.session_ref).toBe('ses_existing');
+  });
+
+  it('rejects unverified policy and thinking claims', () => {
+    const adapter = new TuraAdapter('/fake/tura');
+    expect(() => adapter.spawn({ cwd: '/work', policy: 'anything' })).toThrow('valid policies');
+    expect(() => adapter.spawn({ cwd: '/work', thinking: 'high' })).toThrow('does not support thinking');
+    expect(adapter.capabilities.policies).toEqual({
+      'read-only': null, 'workspace-write': null, 'full-access': null,
+    });
+  });
+
+  it('turns a missing binary and a nonzero exit into failed runs', async () => {
+    const events: WireEvent[] = [];
+    for await (const event of new TuraAdapter('/definitely/missing/tura').deliver(
+      { harness: 'tura', cwd: process.cwd() }, 'hello',
+    )) events.push(event);
+    expect(events.at(-1)).toMatchObject({ type: 'run.completed', status: 'failed' });
+    const command = executable("process.stderr.write('native failure\\n'); process.exit(7);");
+    const failed: WireEvent[] = [];
+    for await (const event of new TuraAdapter(command).deliver(
+      { harness: 'tura', cwd: process.cwd() }, 'hello',
+    )) failed.push(event);
+    expect(failed.at(-1)).toMatchObject({ type: 'run.completed', status: 'failed', final_text: 'native failure' });
+  });
+
+  it('discovers root sessions through Tura session list JSON', () => {
+    const command = executable(`
+const expected = ['--json','session','list','--all'];
+if (JSON.stringify(process.argv.slice(2)) !== JSON.stringify(expected)) process.exit(3);
+console.log(JSON.stringify([{id:'ses_first'},{id:'ses_second'},{title:'missing id'}]));
+`);
+    expect(new TuraAdapter(command).discoverSessions()).toEqual(['ses_first', 'ses_second']);
+  });
+
+  it('asks Tura to abort the native session before force-stopping the local process', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'codor-tura-abort-'));
+    dirs.push(dir);
+    const output = join(dir, 'abort.json');
+    const command = executable(`
+const fs = require('node:fs');
+if (process.argv.includes('abort')) { fs.writeFileSync(process.env.TURA_ABORT_OUT, JSON.stringify(process.argv.slice(2))); process.exit(0); }
+console.log(JSON.stringify({type:'cli.started',sessionID:'ses_abort'}));
+console.log(JSON.stringify({type:'message.part.delta',sessionID:'ses_abort',text:'working'}));
+setInterval(() => {}, 1000);
+`);
+    const adapter = new TuraAdapter(command);
+    const session = adapter.spawn({ cwd: dir });
+    session.env = { TURA_ABORT_OUT: output };
+    const iterator = adapter.deliver(session, 'wait')[Symbol.asyncIterator]();
+    await iterator.next();
+    adapter.interrupt(session);
+    await waitFor(output);
+    expect(JSON.parse(readFileSync(output, 'utf8'))).toEqual(['--cwd', dir, '--json', 'session', 'abort', 'ses_abort']);
+    await iterator.return?.();
+  });
+
+  it('rejects interaction responses because Tura run has no response channel', async () => {
+    await expect(new TuraAdapter().respondInteraction()).rejects.toThrow('no response channel');
+  });
+});
+
+describe('Tura argv construction', () => {
+  it('keeps policy out of argv until a real Tura mapping is verified', () => {
+    const base = { harness: 'tura', cwd: '/work' };
+    expect(turaArgs({ ...base, policy: 'read-only' }, 'go'))
+      .toEqual(turaArgs({ ...base, policy: 'workspace-write' }, 'go'));
+  });
+});

--- a/packages/adapters/tura/src/adapter.spec.ts
+++ b/packages/adapters/tura/src/adapter.spec.ts
@@ -54,7 +54,7 @@ console.log(JSON.stringify({type:'cli.completed',sessionID:'ses_existing',status
     for await (const event of adapter.deliver(session, 'PONG')) events.push(event);
     const done = events.at(-1) as Extract<WireEvent, { type: 'run.completed' }>;
     expect(JSON.parse(done.final_text!)).toEqual({
-      argv: ['--cwd', cwd, 'run', '--output', 'ndjson', '--agent-id', 'balanced', '--session-type', 'coding', '--model', 'openai/gpt-5.6-sol', '--session', 'ses_existing', 'PONG'],
+      argv: ['--cwd', cwd, 'run', '--zsh', '--output', 'ndjson', '--agent-id', 'balanced', '--session-type', 'coding', '--model', 'openai/gpt-5.6-sol', '--session', 'ses_existing', 'PONG'],
       cwd: realpathSync(cwd),
       input: '',
       projectRoot: undefined,
@@ -102,7 +102,7 @@ console.log(JSON.stringify([{id:'ses_first'},{id:'ses_second'},{title:'missing i
 const fs = require('node:fs');
 if (process.argv.includes('abort')) { fs.writeFileSync(process.env.TURA_ABORT_OUT, JSON.stringify(process.argv.slice(2))); process.exit(0); }
 console.log(JSON.stringify({type:'cli.started',sessionID:'ses_abort'}));
-console.log(JSON.stringify({type:'message.part.delta',sessionID:'ses_abort',text:'working'}));
+console.log(JSON.stringify({type:'command.updated',sessionID:'ses_abort',raw:{payload:{properties:{commandID:'cmd_abort',status:'ready',command:{command_type:'zsh',command_line:'{}'}}}}}));
 setInterval(() => {}, 1000);
 `);
     const adapter = new TuraAdapter(command);

--- a/packages/adapters/tura/src/adapter.spec.ts
+++ b/packages/adapters/tura/src/adapter.spec.ts
@@ -57,7 +57,7 @@ console.log(JSON.stringify({type:'cli.completed',sessionID:'ses_existing',status
       argv: ['--cwd', cwd, 'run', '--output', 'ndjson', '--agent-id', 'balanced', '--session-type', 'coding', '--model', 'openai/gpt-5.6-sol', '--session', 'ses_existing', 'PONG'],
       cwd: realpathSync(cwd),
       input: '',
-      projectRoot: cwd,
+      projectRoot: undefined,
     });
     expect(session.session_ref).toBe('ses_existing');
   });

--- a/packages/adapters/tura/src/adapter.ts
+++ b/packages/adapters/tura/src/adapter.ts
@@ -25,6 +25,12 @@ function commandFor(command: string | undefined): string {
   return command;
 }
 
+function turaEnv(sessionEnv?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env = { ...process.env, ...sessionEnv };
+  delete env.TURA_PROJECT_ROOT;
+  return env;
+}
+
 export function turaArgs(session: Session, payload: string): string[] {
   const args = [
     '--cwd', session.cwd,
@@ -96,7 +102,7 @@ export class TuraAdapter implements HarnessAdapter {
       cwd: session.cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,
-      env: { ...process.env, ...session.env, TURA_PROJECT_ROOT: session.cwd },
+      env: turaEnv(session.env),
     });
     this.children.set(session, child);
 
@@ -169,7 +175,7 @@ export class TuraAdapter implements HarnessAdapter {
     ], {
       cwd: session.cwd,
       stdio: 'ignore',
-      env: { ...process.env, ...session.env, TURA_PROJECT_ROOT: session.cwd },
+      env: turaEnv(session.env),
     });
     const forceStop = (): void => {
       if (child && child.exitCode === null && child.signalCode === null) this.signal(child, 'SIGKILL');
@@ -189,7 +195,7 @@ export class TuraAdapter implements HarnessAdapter {
     const result = spawn.sync(this.command, ['--json', 'session', 'list', '--all'], {
       encoding: 'utf8',
       maxBuffer: 4 * 1024 * 1024,
-      env: { ...process.env, TURA_PROJECT_ROOT: process.cwd() },
+      env: turaEnv(),
     });
     if (result.error || result.status !== 0) return [];
     try {

--- a/packages/adapters/tura/src/adapter.ts
+++ b/packages/adapters/tura/src/adapter.ts
@@ -1,0 +1,214 @@
+import { type ChildProcess } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import spawn from 'cross-spawn';
+
+import type {
+  AdapterTurnHooks,
+  HarnessAdapter,
+  Session,
+  SessionRef,
+  SpawnOpts,
+  WireEvent,
+} from '@codor/protocol';
+import { PolicySchema } from '@codor/protocol';
+
+import { createTurnTranslator } from './translate.js';
+
+const ABORT_GRACE_MS = 5_000;
+
+function missingBinary(): Error {
+  return new Error('Tura adapter needs CODOR_TURA_BIN set to the pinned source-built tura binary');
+}
+
+function commandFor(command: string | undefined): string {
+  if (!command) throw missingBinary();
+  return command;
+}
+
+export function turaArgs(session: Session, payload: string): string[] {
+  const args = [
+    '--cwd', session.cwd,
+    'run',
+    '--output', 'ndjson',
+    '--agent-id', process.env.CODOR_TURA_AGENT_ID ?? 'balanced',
+    '--session-type', 'coding',
+  ];
+  if (session.model !== undefined) args.push('--model', session.model);
+  if (session.session_ref !== undefined) args.push('--session', session.session_ref);
+  args.push(payload);
+  return args;
+}
+
+/** A CLI adapter for the source-built Tura release, configured through CODOR_TURA_BIN. */
+export class TuraAdapter implements HarnessAdapter {
+  readonly id = 'tura';
+  readonly capabilities = {
+    resume: true,
+    discover: true,
+    interactiveAttach: true,
+    ask: false,
+    approvals: 'runtime',
+    extensions: false,
+    thinking: false,
+    policies: {
+      'read-only': null,
+      'workspace-write': null,
+      'full-access': null,
+    },
+  } as const;
+
+  private readonly children = new WeakMap<Session, ChildProcess>();
+
+  constructor(private readonly command = process.env.CODOR_TURA_BIN) {}
+
+  spawn(opts: SpawnOpts): Session {
+    if (opts.policy !== undefined && !PolicySchema.safeParse(opts.policy).success) {
+      throw new Error(`unknown policy '${opts.policy}'; valid policies: ${PolicySchema.options.join(', ')}`);
+    }
+    if (opts.thinking !== undefined) {
+      throw new Error("adapter 'tura' does not support thinking levels");
+    }
+    return {
+      harness: this.id,
+      cwd: opts.cwd,
+      model: opts.model,
+      policy: opts.policy,
+    };
+  }
+
+  attach(session_ref: SessionRef): Session {
+    return { harness: this.id, session_ref, cwd: process.cwd() };
+  }
+
+  async *deliver(
+    session: Session,
+    payload: string,
+    hooks: AdapterTurnHooks = {},
+  ): AsyncIterable<WireEvent> {
+    let command: string;
+    try {
+      command = commandFor(this.command);
+    } catch (error) {
+      yield { type: 'run.completed', status: 'failed', error: String(error), final_text: String(error) };
+      return;
+    }
+    const child = spawn(command, turaArgs(session, payload), {
+      cwd: session.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: true,
+      env: { ...process.env, ...session.env, TURA_PROJECT_ROOT: session.cwd },
+    });
+    this.children.set(session, child);
+
+    let stderr = '';
+    child.stderr!.setEncoding('utf8');
+    child.stderr!.on('data', (chunk: string) => {
+      stderr = `${stderr}${chunk}`.slice(-8192);
+    });
+    let childError: Error | undefined;
+    const spawned = new Promise<void>((resolve, reject) => {
+      child.once('spawn', resolve);
+      child.once('error', (error) => {
+        childError = error;
+        reject(error);
+      });
+    });
+    const closed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+      (resolve) => child.once('close', (code, signal) => resolve({ code, signal })),
+    );
+
+    const translator = createTurnTranslator();
+    let reportedSessionRef: string | undefined;
+    const reportSessionRef = (): void => {
+      const discovered = translator.sessionId();
+      if (discovered === undefined || discovered === reportedSessionRef) return;
+      session.session_ref = discovered;
+      reportedSessionRef = discovered;
+      hooks.onSessionRef?.(discovered);
+    };
+
+    try {
+      try {
+        await spawned;
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        yield* translator.end({ status: 'failed', error: detail });
+        return;
+      }
+      hooks.onStarted?.({ pid: child.pid, process_group_id: child.pid });
+      const lines = createInterface({ input: child.stdout! });
+      for await (const line of lines) {
+        for (const event of translator.push(line)) {
+          reportSessionRef();
+          yield event;
+        }
+        reportSessionRef();
+      }
+      const exit = await closed;
+      const detail = stderr.trim() || childError?.message;
+      const status = childError !== undefined || (exit.code !== null && exit.code !== 0)
+        ? 'failed'
+        : exit.code === 0
+          ? 'completed'
+          : 'interrupted';
+      yield* translator.end({ status, ...(detail && { error: detail }) });
+    } finally {
+      this.children.delete(session);
+      if (child.exitCode === null && child.signalCode === null) this.signal(child, 'SIGKILL');
+    }
+  }
+
+  interrupt(session: Session): void {
+    const child = this.children.get(session);
+    if (session.session_ref === undefined || !this.command) {
+      if (child) this.signal(child, 'SIGINT');
+      return;
+    }
+    const abort = spawn(this.command, [
+      '--cwd', session.cwd, '--json', 'session', 'abort', session.session_ref,
+    ], {
+      cwd: session.cwd,
+      stdio: 'ignore',
+      env: { ...process.env, ...session.env, TURA_PROJECT_ROOT: session.cwd },
+    });
+    const forceStop = (): void => {
+      if (child && child.exitCode === null && child.signalCode === null) this.signal(child, 'SIGKILL');
+    };
+    if (!child) return;
+    const timer = setTimeout(forceStop, ABORT_GRACE_MS);
+    child.once('close', () => clearTimeout(timer));
+    abort.once('error', forceStop);
+  }
+
+  respondInteraction(): Promise<void> {
+    return Promise.reject(new Error('Tura run exposes no response channel to Codor'));
+  }
+
+  discoverSessions(): SessionRef[] {
+    if (!this.command) return [];
+    const result = spawn.sync(this.command, ['--json', 'session', 'list', '--all'], {
+      encoding: 'utf8',
+      maxBuffer: 4 * 1024 * 1024,
+      env: { ...process.env, TURA_PROJECT_ROOT: process.cwd() },
+    });
+    if (result.error || result.status !== 0) return [];
+    try {
+      const sessions = JSON.parse(result.stdout) as { id?: unknown }[];
+      if (!Array.isArray(sessions)) return [];
+      return sessions.flatMap((session) =>
+        typeof session.id === 'string' && session.id !== '' ? [session.id] : [],
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  private signal(child: ChildProcess, signal: NodeJS.Signals): void {
+    if (child.pid === undefined) return;
+    try {
+      process.kill(-child.pid, signal);
+    } catch {
+      child.kill(signal);
+    }
+  }
+}

--- a/packages/adapters/tura/src/adapter.ts
+++ b/packages/adapters/tura/src/adapter.ts
@@ -35,6 +35,10 @@ export function turaArgs(session: Session, payload: string): string[] {
   const args = [
     '--cwd', session.cwd,
     'run',
+    // Tura's plain run surface can complete the model turn then return a
+    // non-zero runtime status. The gateway-owned command-run surface is the
+    // proven headless contract used by Wheel's source wrappers.
+    '--zsh',
     '--output', 'ndjson',
     '--agent-id', process.env.CODOR_TURA_AGENT_ID ?? 'balanced',
     '--session-type', 'coding',
@@ -147,6 +151,7 @@ export class TuraAdapter implements HarnessAdapter {
         for (const event of translator.push(line)) {
           reportSessionRef();
           yield event;
+          if (event.type === 'run.completed') return;
         }
         reportSessionRef();
       }

--- a/packages/adapters/tura/src/index.ts
+++ b/packages/adapters/tura/src/index.ts
@@ -1,0 +1,3 @@
+export { TuraAdapter, turaArgs } from './adapter.js';
+export { createTurnTranslator } from './translate.js';
+export type { TurnTranslator } from './translate.js';

--- a/packages/adapters/tura/src/translate.spec.ts
+++ b/packages/adapters/tura/src/translate.spec.ts
@@ -53,4 +53,33 @@ describe('Tura NDJSON translation', () => {
     expect(translator.push('{"type":"cli.completed","sessionID":"ses_bad","status":"failed","finalText":"gateway error"}'))
       .toEqual([{ type: 'run.completed', status: 'failed', final_text: 'gateway error', error: 'gateway error' }]);
   });
+
+  it('maps the current source runtime command payload without duplicate results', () => {
+    const translator = createTurnTranslator();
+    const ready = translator.push(JSON.stringify({
+      type: 'command.updated', sessionID: 'ses_current', status: 'ready', raw: { payload: { properties: {
+        commandID: 'cmd_current', status: 'ready', command: { command_type: 'zsh', command_line: '{"command":"pwd"}' },
+      } } },
+    }));
+    const completed = translator.push(JSON.stringify({
+      type: 'command.updated', sessionID: 'ses_current', status: 'completed', raw: { payload: { properties: {
+        commandID: 'cmd_current', status: 'completed', command: { command_type: 'zsh', command_line: '{"command":"pwd"}' },
+        result: { success: true, output: { stdout: '/work\\n', stderr: '' } },
+      } } },
+    }));
+    const duplicate = translator.push(JSON.stringify({
+      type: 'command.updated', sessionID: 'ses_current', status: 'completed', raw: { payload: { properties: {
+        commandID: 'cmd_current', status: 'completed', command: { command_type: 'zsh', command_line: '{"command":"pwd"}' }, result: null,
+      } } },
+    }));
+
+    expect(ready).toEqual([{ type: 'run.item', item_type: 'tool_call', payload: {
+      call_id: 'cmd_current', tool: 'zsh', title: 'zsh', input: { command: 'pwd' },
+    } }]);
+    expect(completed).toEqual([{ type: 'run.item', item_type: 'tool_result', payload: {
+      call_id: 'cmd_current', status: 'ok', output_text: '/work\\n',
+      raw: expect.any(Object),
+    } }]);
+    expect(duplicate).toEqual([]);
+  });
 });

--- a/packages/adapters/tura/src/translate.spec.ts
+++ b/packages/adapters/tura/src/translate.spec.ts
@@ -68,7 +68,8 @@ describe('Tura NDJSON translation', () => {
     }));
     const duplicate = translator.push(JSON.stringify({
       type: 'command.updated', sessionID: 'ses_current', status: 'completed', raw: { payload: { properties: {
-        commandID: 'cmd_current', status: 'completed', command: { command_type: 'zsh', command_line: '{"command":"pwd"}' }, result: null,
+        commandID: 'cmd_current', status: 'completed', command: { command_type: 'zsh', command_line: '{"command":"pwd"}' },
+        result: { success: true, output: { stdout: '/work\\n', stderr: '' } },
       } } },
     }));
 
@@ -92,5 +93,18 @@ describe('Tura NDJSON translation', () => {
     expect(translator.push(JSON.stringify({
       type: 'session.status', sessionID: 'ses_resume', status: 'idle',
     }))).toEqual([{ type: 'run.completed', status: 'completed', final_text: 'PONG' }]);
+  });
+
+  it('ignores idle before a terminal turn event', () => {
+    const translator = createTurnTranslator();
+    expect(translator.push(JSON.stringify({
+      type: 'session.status', sessionID: 'ses_resume', status: 'idle',
+    }))).toEqual([]);
+    expect(translator.push(JSON.stringify({
+      type: 'message.part.delta', sessionID: 'ses_resume', text: 'ONG',
+    }))).toEqual([]);
+    expect(translator.push(JSON.stringify({
+      type: 'session.status', sessionID: 'ses_resume', status: 'idle',
+    }))).toEqual([]);
   });
 });

--- a/packages/adapters/tura/src/translate.spec.ts
+++ b/packages/adapters/tura/src/translate.spec.ts
@@ -15,7 +15,6 @@ describe('Tura NDJSON translation', () => {
 
     expect(translator.sessionId()).toBe('ses_tura');
     expect(events).toEqual([
-      { type: 'run.item', item_type: 'text_delta', payload: { text: 'PONG' } },
       {
         type: 'run.item', item_type: 'tool_call',
         payload: {
@@ -81,5 +80,17 @@ describe('Tura NDJSON translation', () => {
       raw: expect.any(Object),
     } }]);
     expect(duplicate).toEqual([]);
+  });
+
+  it('normalizes an idle resumed command-run session', () => {
+    const translator = createTurnTranslator();
+    expect(translator.push(JSON.stringify({
+      type: 'message.updated', sessionID: 'ses_resume', text: 'PONG', raw: { payload: { properties: {
+        info: { role: 'assistant' },
+      } } },
+    }))).toEqual([]);
+    expect(translator.push(JSON.stringify({
+      type: 'session.status', sessionID: 'ses_resume', status: 'idle',
+    }))).toEqual([{ type: 'run.completed', status: 'completed', final_text: 'PONG' }]);
   });
 });

--- a/packages/adapters/tura/src/translate.spec.ts
+++ b/packages/adapters/tura/src/translate.spec.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs';
+
+import { parseRunItemPayload, type WireEvent } from '@codor/protocol';
+import { describe, expect, it } from 'vitest';
+
+import { createTurnTranslator } from './translate.js';
+
+describe('Tura NDJSON translation', () => {
+  it('maps a native run, its tool lifecycle, and exactly one terminal event', () => {
+    const translator = createTurnTranslator();
+    const events = readFileSync(new URL('../fixtures/native-run.jsonl', import.meta.url), 'utf8')
+      .split('\n')
+      .flatMap((line) => translator.push(line));
+    events.push(...translator.end({ status: 'completed' }));
+
+    expect(translator.sessionId()).toBe('ses_tura');
+    expect(events).toEqual([
+      { type: 'run.item', item_type: 'text_delta', payload: { text: 'PONG' } },
+      {
+        type: 'run.item', item_type: 'tool_call',
+        payload: {
+          call_id: 'cmd_1', tool: 'command_run', title: 'Command run',
+          input: { command_line: 'pwd' },
+        },
+      },
+      {
+        type: 'run.item', item_type: 'tool_result',
+        payload: {
+          call_id: 'cmd_1', status: 'ok', output_text: '/work',
+          raw: { payload: { properties: { commandID: 'cmd_1', status: 'completed', command: 'command_run', output: '/work' } } },
+        },
+      },
+      { type: 'run.completed', status: 'completed', final_text: 'PONG' },
+    ]);
+    for (const event of events) {
+      if (event.type === 'run.item') {
+        expect(parseRunItemPayload(event.item_type, event.payload).success).toBe(true);
+      }
+    }
+  });
+
+  it('fails cleanly for a native failure and ignores malformed or future records', () => {
+    const translator = createTurnTranslator();
+    expect(translator.push('not-json')).toEqual([]);
+    expect(translator.push('{"type":"future"}')).toEqual([]);
+    expect(translator.push('{"type":"cli.failed","sessionID":"ses_bad","error":"auth required"}'))
+      .toEqual([{ type: 'run.completed', status: 'failed', final_text: 'auth required', error: 'auth required' }]);
+    expect(translator.end({ status: 'failed' })).toEqual([]);
+  });
+
+  it('does not mistake a completed CLI process for a completed native turn', () => {
+    const translator = createTurnTranslator();
+    expect(translator.push('{"type":"cli.completed","sessionID":"ses_bad","status":"failed","finalText":"gateway error"}'))
+      .toEqual([{ type: 'run.completed', status: 'failed', final_text: 'gateway error', error: 'gateway error' }]);
+  });
+});

--- a/packages/adapters/tura/src/translate.ts
+++ b/packages/adapters/tura/src/translate.ts
@@ -3,6 +3,7 @@ import type { WireEvent } from '@codor/protocol';
 interface TuraEvent {
   type?: string;
   sessionID?: string;
+  messageID?: string;
   text?: string;
   finalText?: string;
   status?: string;
@@ -10,6 +11,7 @@ interface TuraEvent {
   raw?: {
     payload?: {
       properties?: {
+        info?: { role?: unknown };
         commandID?: unknown;
         status?: unknown;
         command?: unknown;
@@ -67,6 +69,7 @@ export interface TurnTranslator {
 export function createTurnTranslator(): TurnTranslator {
   let sessionId: string | undefined;
   let finalText = '';
+  let streamedText = '';
   let streamError: string | undefined;
   let terminal = false;
   const toolCalls = new Set<string>();
@@ -77,7 +80,7 @@ export function createTurnTranslator(): TurnTranslator {
   ): WireEvent[] => {
     if (terminal) return [];
     terminal = true;
-    const resolved = finalText || streamError || error;
+    const resolved = finalText || streamedText || streamError || error;
     return [{
       type: 'run.completed',
       status,
@@ -102,8 +105,19 @@ export function createTurnTranslator(): TurnTranslator {
       switch (event.type) {
         case 'message.part.delta':
           if (typeof event.text !== 'string' || event.text === '') return [];
-          finalText += event.text;
-          return [{ type: 'run.item', item_type: 'text_delta', payload: { text: event.text } }];
+          // The source gateway can publish a partial delta after it has already
+          // committed the final assistant message (for example `ONG` then
+          // `PONG`). Keep it as a fallback, but publish the authoritative
+          // final/message update only once at completion.
+          streamedText += event.text;
+          return [];
+        case 'message.updated':
+          // A resumed command-run turn reports its final answer through a
+          // repeatable message update before reporting the session as idle.
+          if (event.raw?.payload?.properties?.info?.role === 'assistant' && typeof event.text === 'string') {
+            finalText = event.text;
+          }
+          return [];
         case 'command.updated': {
           const properties = event.raw?.payload?.properties;
           const callId = typeof properties?.commandID === 'string' && properties.commandID !== ''
@@ -147,6 +161,10 @@ export function createTurnTranslator(): TurnTranslator {
         case 'cli.failed':
           streamError = errorText(event.error) ?? 'Tura reported a failed run';
           return finish('failed');
+        case 'session.status':
+          // `run --zsh --session` remains subscribed when the native session
+          // reaches idle instead of emitting cli.completed.
+          return event.status === 'idle' ? finish('completed') : [];
         default:
           return [];
       }

--- a/packages/adapters/tura/src/translate.ts
+++ b/packages/adapters/tura/src/translate.ts
@@ -69,10 +69,11 @@ export interface TurnTranslator {
 export function createTurnTranslator(): TurnTranslator {
   let sessionId: string | undefined;
   let finalText = '';
-  let streamedText = '';
   let streamError: string | undefined;
   let terminal = false;
   const toolCalls = new Set<string>();
+  const toolResults = new Set<string>();
+  let sawTerminalTurnActivity = false;
 
   const finish = (
     status: 'completed' | 'failed' | 'interrupted',
@@ -80,7 +81,7 @@ export function createTurnTranslator(): TurnTranslator {
   ): WireEvent[] => {
     if (terminal) return [];
     terminal = true;
-    const resolved = finalText || streamedText || streamError || error;
+    const resolved = finalText || streamError || error;
     return [{
       type: 'run.completed',
       status,
@@ -105,17 +106,15 @@ export function createTurnTranslator(): TurnTranslator {
       switch (event.type) {
         case 'message.part.delta':
           if (typeof event.text !== 'string' || event.text === '') return [];
-          // The source gateway can publish a partial delta after it has already
-          // committed the final assistant message (for example `ONG` then
-          // `PONG`). Keep it as a fallback, but publish the authoritative
-          // final/message update only once at completion.
-          streamedText += event.text;
+          // Source deltas can be partial or reordered. The authoritative final
+          // is the assistant message update or cli.completed.finalText.
           return [];
         case 'message.updated':
           // A resumed command-run turn reports its final answer through a
           // repeatable message update before reporting the session as idle.
           if (event.raw?.payload?.properties?.info?.role === 'assistant' && typeof event.text === 'string') {
             finalText = event.text;
+            sawTerminalTurnActivity = true;
           }
           return [];
         case 'command.updated': {
@@ -141,14 +140,20 @@ export function createTurnTranslator(): TurnTranslator {
             });
           }
           const result = properties?.result;
-          if (status !== undefined && TERMINAL_COMMAND_STATUSES.has(status) && (properties?.output !== undefined || result != null)) {
+          if (
+            status !== undefined && TERMINAL_COMMAND_STATUSES.has(status) &&
+            (properties?.output !== undefined || result != null) && !toolResults.has(callId)
+          ) {
+            toolResults.add(callId);
+            sawTerminalTurnActivity = true;
+            const output = outputText(properties?.output ?? result?.output);
             events.push({
               type: 'run.item',
               item_type: 'tool_result',
               payload: {
                 call_id: callId,
                 status: result?.success === false || (status !== 'completed' && status !== 'succeeded') ? 'error' : 'ok',
-                ...(outputText(properties?.output ?? result?.output) && { output_text: outputText(properties?.output ?? result?.output) }),
+                ...(output && { output_text: output }),
                 raw: event.raw,
               },
             });
@@ -164,7 +169,7 @@ export function createTurnTranslator(): TurnTranslator {
         case 'session.status':
           // `run --zsh --session` remains subscribed when the native session
           // reaches idle instead of emitting cli.completed.
-          return event.status === 'idle' ? finish('completed') : [];
+          return event.status === 'idle' && sawTerminalTurnActivity ? finish('completed') : [];
         default:
           return [];
       }

--- a/packages/adapters/tura/src/translate.ts
+++ b/packages/adapters/tura/src/translate.ts
@@ -15,6 +15,10 @@ interface TuraEvent {
         command?: unknown;
         input?: unknown;
         output?: unknown;
+        result?: {
+          success?: unknown;
+          output?: { stdout?: unknown; stderr?: unknown };
+        };
       };
     };
   };
@@ -28,6 +32,29 @@ function errorText(value: unknown): string | undefined {
   const candidate = value as { message?: unknown; error?: unknown };
   if (typeof candidate.message === 'string') return candidate.message;
   return typeof candidate.error === 'string' ? candidate.error : undefined;
+}
+
+function commandDetails(value: unknown): { tool: string; input?: unknown } {
+  if (!value || typeof value !== 'object') {
+    return { tool: typeof value === 'string' ? value : 'command_run' };
+  }
+  const command = value as { command_type?: unknown; command_line?: unknown };
+  let input: unknown = command.command_line;
+  if (typeof input === 'string') {
+    try { input = JSON.parse(input) as unknown; } catch { /* retain the raw command line */ }
+  }
+  return {
+    tool: typeof command.command_type === 'string' ? command.command_type : 'command_run',
+    ...(input !== undefined && { input }),
+  };
+}
+
+function outputText(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (!value || typeof value !== 'object') return undefined;
+  const output = value as { stdout?: unknown; stderr?: unknown };
+  const text = [output.stdout, output.stderr].filter((part): part is string => typeof part === 'string' && part !== '').join('');
+  return text || undefined;
 }
 
 export interface TurnTranslator {
@@ -83,7 +110,7 @@ export function createTurnTranslator(): TurnTranslator {
             ? properties.commandID
             : 'tura-command-run';
           const status = typeof properties?.status === 'string' ? properties.status : undefined;
-          const tool = typeof properties?.command === 'string' ? properties.command : 'command_run';
+          const command = commandDetails(properties?.command);
           const events: WireEvent[] = [];
           if (!toolCalls.has(callId)) {
             toolCalls.add(callId);
@@ -92,20 +119,22 @@ export function createTurnTranslator(): TurnTranslator {
               item_type: 'tool_call',
               payload: {
                 call_id: callId,
-                tool,
-                title: tool === 'command_run' ? 'Command run' : tool,
+                tool: command.tool,
+                title: command.tool === 'command_run' ? 'Command run' : command.tool,
                 ...(properties?.input !== undefined && { input: properties.input }),
+                ...(properties?.input === undefined && command.input !== undefined && { input: command.input }),
               },
             });
           }
-          if (status !== undefined && TERMINAL_COMMAND_STATUSES.has(status)) {
+          const result = properties?.result;
+          if (status !== undefined && TERMINAL_COMMAND_STATUSES.has(status) && (properties?.output !== undefined || result != null)) {
             events.push({
               type: 'run.item',
               item_type: 'tool_result',
               payload: {
                 call_id: callId,
-                status: status === 'completed' || status === 'succeeded' ? 'ok' : 'error',
-                ...(typeof properties?.output === 'string' && { output_text: properties.output }),
+                status: result?.success === false || (status !== 'completed' && status !== 'succeeded') ? 'error' : 'ok',
+                ...(outputText(properties?.output ?? result?.output) && { output_text: outputText(properties?.output ?? result?.output) }),
                 raw: event.raw,
               },
             });

--- a/packages/adapters/tura/src/translate.ts
+++ b/packages/adapters/tura/src/translate.ts
@@ -1,0 +1,130 @@
+import type { WireEvent } from '@codor/protocol';
+
+interface TuraEvent {
+  type?: string;
+  sessionID?: string;
+  text?: string;
+  finalText?: string;
+  status?: string;
+  error?: unknown;
+  raw?: {
+    payload?: {
+      properties?: {
+        commandID?: unknown;
+        status?: unknown;
+        command?: unknown;
+        input?: unknown;
+        output?: unknown;
+      };
+    };
+  };
+}
+
+const TERMINAL_COMMAND_STATUSES = new Set(['completed', 'succeeded', 'failed', 'error', 'cancelled']);
+
+function errorText(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (!value || typeof value !== 'object') return undefined;
+  const candidate = value as { message?: unknown; error?: unknown };
+  if (typeof candidate.message === 'string') return candidate.message;
+  return typeof candidate.error === 'string' ? candidate.error : undefined;
+}
+
+export interface TurnTranslator {
+  push(line: string): WireEvent[];
+  end(outcome: { status: 'completed' | 'failed' | 'interrupted'; error?: string }): WireEvent[];
+  sessionId(): string | undefined;
+}
+
+/** Translate Tura's documented `run --output ndjson` stream into Codor events. */
+export function createTurnTranslator(): TurnTranslator {
+  let sessionId: string | undefined;
+  let finalText = '';
+  let streamError: string | undefined;
+  let terminal = false;
+  const toolCalls = new Set<string>();
+
+  const finish = (
+    status: 'completed' | 'failed' | 'interrupted',
+    error?: string,
+  ): WireEvent[] => {
+    if (terminal) return [];
+    terminal = true;
+    const resolved = finalText || streamError || error;
+    return [{
+      type: 'run.completed',
+      status,
+      ...(resolved && { final_text: resolved }),
+      ...(status !== 'completed' && resolved && { error: resolved }),
+    }];
+  };
+
+  return {
+    sessionId: () => sessionId,
+
+    push(line: string): WireEvent[] {
+      if (line.trim() === '') return [];
+      let event: TuraEvent;
+      try {
+        event = JSON.parse(line) as TuraEvent;
+      } catch {
+        return [];
+      }
+      if (typeof event.sessionID === 'string' && event.sessionID !== '') sessionId ??= event.sessionID;
+
+      switch (event.type) {
+        case 'message.part.delta':
+          if (typeof event.text !== 'string' || event.text === '') return [];
+          finalText += event.text;
+          return [{ type: 'run.item', item_type: 'text_delta', payload: { text: event.text } }];
+        case 'command.updated': {
+          const properties = event.raw?.payload?.properties;
+          const callId = typeof properties?.commandID === 'string' && properties.commandID !== ''
+            ? properties.commandID
+            : 'tura-command-run';
+          const status = typeof properties?.status === 'string' ? properties.status : undefined;
+          const tool = typeof properties?.command === 'string' ? properties.command : 'command_run';
+          const events: WireEvent[] = [];
+          if (!toolCalls.has(callId)) {
+            toolCalls.add(callId);
+            events.push({
+              type: 'run.item',
+              item_type: 'tool_call',
+              payload: {
+                call_id: callId,
+                tool,
+                title: tool === 'command_run' ? 'Command run' : tool,
+                ...(properties?.input !== undefined && { input: properties.input }),
+              },
+            });
+          }
+          if (status !== undefined && TERMINAL_COMMAND_STATUSES.has(status)) {
+            events.push({
+              type: 'run.item',
+              item_type: 'tool_result',
+              payload: {
+                call_id: callId,
+                status: status === 'completed' || status === 'succeeded' ? 'ok' : 'error',
+                ...(typeof properties?.output === 'string' && { output_text: properties.output }),
+                raw: event.raw,
+              },
+            });
+          }
+          return events;
+        }
+        case 'cli.completed':
+          if (typeof event.finalText === 'string' && event.finalText !== '') finalText = event.finalText;
+          return finish(event.status === 'completed' ? 'completed' : 'failed');
+        case 'cli.failed':
+          streamError = errorText(event.error) ?? 'Tura reported a failed run';
+          return finish('failed');
+        default:
+          return [];
+      }
+    },
+
+    end(outcome): WireEvent[] {
+      return finish(outcome.status, outcome.error);
+    },
+  };
+}

--- a/packages/adapters/tura/tsconfig.json
+++ b/packages/adapters/tura/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.spec.ts"]
+}

--- a/packages/switchboard/package.json
+++ b/packages/switchboard/package.json
@@ -25,6 +25,7 @@
     "@codor/adapter-cursor": "workspace:*",
     "@codor/adapter-gemini": "workspace:*",
     "@codor/adapter-opencode": "workspace:*",
+    "@codor/adapter-tura": "workspace:*",
     "@codor/protocol": "workspace:*",
     "better-sqlite3": "^12.11.1",
     "chokidar": "^5.0.0",

--- a/packages/switchboard/src/adapter-registry.spec.ts
+++ b/packages/switchboard/src/adapter-registry.spec.ts
@@ -26,6 +26,7 @@ describe('adapter registry spawn controls', () => {
       ['cursor', false, undefined],
       ['gemini', false, undefined],
       ['opencode', true, ['low', 'medium', 'high']],
+      ['tura', false, undefined],
     ]);
   });
 

--- a/packages/switchboard/src/adapter-registry.ts
+++ b/packages/switchboard/src/adapter-registry.ts
@@ -8,6 +8,7 @@ import { CopilotAdapter } from '@codor/adapter-copilot';
 import { CursorAdapter } from '@codor/adapter-cursor';
 import { GeminiAdapter } from '@codor/adapter-gemini';
 import { OpenCodeAdapter } from '@codor/adapter-opencode';
+import { TuraAdapter } from '@codor/adapter-tura';
 import {
   type AdapterCapabilities,
   DEFAULT_THINKING_LEVELS,
@@ -39,6 +40,7 @@ const builtinFactories = {
   cursor: () => new CursorAdapter(),
   gemini: () => new GeminiAdapter(),
   opencode: () => new OpenCodeAdapter(),
+  tura: () => new TuraAdapter(),
 } satisfies Record<string, AdapterFactory>;
 
 export const BUILTIN_ADAPTER_IDS = Object.freeze(Object.keys(builtinFactories));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,19 @@ importers:
         specifier: ^6.0.6
         version: 6.0.6
 
+  packages/adapters/tura:
+    dependencies:
+      '@codor/protocol':
+        specifier: workspace:*
+        version: link:../../protocol
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
+    devDependencies:
+      '@types/cross-spawn':
+        specifier: ^6.0.6
+        version: 6.0.6
+
   packages/bridges/core:
     dependencies:
       '@codor/protocol':
@@ -184,6 +197,9 @@ importers:
       '@codor/adapter-opencode':
         specifier: workspace:*
         version: link:../adapters/opencode
+      '@codor/adapter-tura':
+        specifier: workspace:*
+        version: link:../adapters/tura
       '@codor/protocol':
         specifier: workspace:*
         version: link:../protocol


### PR DESCRIPTION
## Summary

Adds a built-in Tura harness adapter that invokes the pinned source-built CLI, translates its NDJSON lifecycle into Codor events, supports native session resume and cancellation, and normalizes source-runtime terminal quirks.

The adapter uses the proven `run --zsh` surface. Resumed source sessions finish by reporting `session.status: idle` while their CLI remains subscribed; the adapter treats that as completion only after genuine terminal-turn activity. It also ignores partial/reordered source deltas in favour of authoritative assistant message updates or `cli.completed.finalText`.

## Validation

- `corepack pnpm --filter @codor/adapter-tura test` — 13 tests passed
- `corepack pnpm --filter @codor/adapter-tura build`
- `corepack pnpm --filter @codor/switchboard build`
- `corepack pnpm exec vitest run src/adapter-registry.spec.ts` — 15 tests passed
- Clean-room source-Tura acceptance: initial and resumed turns returned exactly `PONG`; Codor interruption ended a slow turn as `interrupted`.

— Codex · gpt-5.6-sol
