### PR TITLE
feat: add Grok CLI adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Install and sign in to at least one supported agent:
 [Cursor](https://cursor.com/cli),
 [Antigravity](https://antigravity.google/docs/cli/getting-started) (`agy`),
 [Gemini](https://github.com/google-gemini/gemini-cli),
+[Grok Build](https://docs.x.ai/build/cli/headless-scripting),
 [Copilot](https://docs.github.com/en/copilot/how-tos/copilot-cli/cli-getting-started), or
 [OpenCode](https://opencode.ai/docs/).
 
@@ -163,7 +164,7 @@ codor attach -r <channel-name> planner
 ```
 
 This opens the native resumable session and returns it to Codor when you exit. It supports
-resumable Claude Code, Codex, Gemini, OpenCode, and Copilot members. See the complete
+resumable Claude Code, Codex, Gemini, Grok, OpenCode, and Copilot members. See the complete
 [existing-session guide](docs/JOIN.md).
 <!-- harn:end readme-explains-existing-session-custody -->
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,7 +61,7 @@ interface HarnessAdapter {
 ```
 
 Design rule: **adapters expose one normalized turn contract while using the provider-native
-runtime that preserves a session correctly.** Copilot, Gemini, and OpenCode remain plain
+runtime that preserves a session correctly.** Copilot, Gemini, Grok, and OpenCode remain plain
 supervised per-turn CLI subprocesses. Claude's first-party Agent SDK and Codex's app-server
 are deliberate persistent-runtime exceptions. The switchboard still sees the same
 `deliver()`/interaction/interrupt/session-ref boundary.
@@ -226,7 +226,7 @@ verified in M0 before any code lands (unverified entries marked ⚠).
 | Claude session driving | `@anthropic-ai/claude-agent-sdk` (`query()` streaming input + `resume`) | depend | one long-lived query per member; first-party callbacks for permissions/hooks; engine-native compaction |
 | Codex session driving | `codex app-server` JSON-RPC (`thread/start`, `thread/resume`, `turn/start`) | depend | one persistent supervised process per member; native usage and compaction notifications |
 | Harness normalization | Zed ACP (`agent-client-protocol` + `claude-agent-acp`, both Apache-2.0) | rejected as driver layer (M0 verdict) | P0.2 spike: resume OK, usage coarse (per-turn tokens still a Draft RFD), subagent visibility absent by design; codex adapter is third-party (JetBrains). CLI drivers stay; ACP = candidate future fourth adapter |
-| Additional harness adapters (Copilot CLI, OpenCode, Gemini, Pi, …) | paseo's adapter set as the *behavioral reference* (AGPL forbids copying code, not learning from it); ACP adapters where they exist (Apache/MIT); each harness's first-party headless docs | pattern / depend | per harness: read their connector → write a behavioral spec (`packages/adapters/<harness>/NOTES.md`: invocation, resume, session store, event format, quirks) → implement our small adapter from the spec against the six-method interface. No paseo code in this repo, in-process or sidecar |
+| Additional harness adapters (Copilot CLI, OpenCode, Gemini, Grok, Pi, …) | paseo's adapter set as the *behavioral reference* (AGPL forbids copying code, not learning from it); ACP adapters where they exist (Apache/MIT); each harness's first-party headless docs | pattern / depend | per harness: read their connector → write a behavioral spec (`packages/adapters/<harness>/NOTES.md`: invocation, resume, session store, event format, quirks) → implement our small adapter from the spec against the six-method interface. No paseo code in this repo, in-process or sidecar |
 | P2P transport | `hyperswarm` (+ DHT, Noise) — walkie's stack (**MIT, verified P0.2**) | depend; walkie as pattern/vendor | `line:secret` → DHT topic, exactly walkie's channel model; walkie's `listen()/send()` lib is MIT (`walkie-sh` v1.5.0) — reuse permitted with attribution, else hyperswarm directly |
 | Tailnet access | Tailscale (user-supplied): `tailscale serve` for TLS; app connectors for custom-domain team access | depend | zero code: bind the tailnet IP; connector setup is documentation, not software |
 | Session-store discovery | partyline-sh/cli (MIT, Go) | port | its readers for `~/.claude` / `~/.codex` / Gemini session stores solve attach-by-session-id; port the formats to TS (Go binary doesn't transplant into a Node daemon) |

--- a/packages/adapters/grok/NOTES.md
+++ b/packages/adapters/grok/NOTES.md
@@ -1,0 +1,47 @@
+# Grok CLI adapter
+
+This adapter drives xAI's official `grok` CLI in headless mode. The behavioral
+specification is based on the xAI CLI documentation checked on 2026-07-23:
+
+- <https://docs.x.ai/build/cli/headless-scripting>
+- <https://docs.x.ai/build/cli/reference>
+- <https://docs.x.ai/developers/models>
+- <https://docs.x.ai/developers/model-capabilities/text/reasoning>
+
+## Invocation
+
+```text
+grok -p PAYLOAD --output-format streaming-json --no-auto-update
+grok -p PAYLOAD --output-format streaming-json --no-auto-update --resume SESSION_ID
+```
+
+The adapter adds `--model MODEL`, `--effort low|medium|high`, and
+`--always-approve` for the corresponding Codor controls. The child runs with
+the member working directory and merged member environment; stdin is unused.
+
+## Lifecycle and capabilities
+
+Grok stores headless sessions under `~/.grok/sessions`. The CLI creates and
+reports a session id for new members, resumes by id, and the adapter discovers
+UUID-named session entries in that directory. Interactive attach uses the documented native
+`grok --resume ID` flow.
+
+The headless stream has no documented response channel for ask cards or runtime
+approval answers, so `ask:false` and `approvals:'spawn-time'` are intentional.
+Subagent and live-inbox events are not advertised until a first-party stream
+capture establishes them.
+
+The CLI documents `--always-approve`, but does not document native mappings for
+read-only or workspace-write. Those policy entries are therefore `null`, while
+full-access is represented by `--always-approve`; the UI will show the two
+non-enforced tiers honestly.
+
+## Privacy note
+
+Grok is a cloud coding agent. Review xAI's current data, privacy, and codebase
+upload settings before enabling it for sensitive repositories. Codor does not
+intercept or redact provider traffic.
+
+The checked-in translator accepts the documented Responses-style streaming event
+names and the common CLI aliases used by current builds. A scrubbed live capture
+should be added before advertising additional tool, subagent, or usage behavior.

--- a/packages/adapters/grok/fixtures/SYNTHETIC.md
+++ b/packages/adapters/grok/fixtures/SYNTHETIC.md
@@ -1,0 +1,3 @@
+These fixture lines reproduce the native `grok --output-format streaming-json`
+event shape observed from Grok Build 0.2.101. They contain no provider output
+or credentials and are used only to pin the translator contract.

--- a/packages/adapters/grok/fixtures/streaming-native.jsonl
+++ b/packages/adapters/grok/fixtures/streaming-native.jsonl
@@ -1,0 +1,4 @@
+{"type":"text","data":"hello "}
+{"type":"thought","data":"checking the answer"}
+{"type":"text","data":"world"}
+{"type":"end","stopReason":"EndTurn","sessionId":"22222222-2222-4222-8222-222222222222"}

--- a/packages/adapters/grok/package.json
+++ b/packages/adapters/grok/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@codor/adapter-grok",
+  "version": "0.10.4",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@codor/protocol": "workspace:*",
+    "cross-spawn": "^7.0.6"
+  },
+  "devDependencies": {
+    "@types/cross-spawn": "^6.0.6"
+  }
+}

--- a/packages/adapters/grok/src/adapter.spec.ts
+++ b/packages/adapters/grok/src/adapter.spec.ts
@@ -1,0 +1,77 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { WireEvent } from '@codor/protocol';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { GrokAdapter, grokApprovalArgs, grokArgs } from './adapter.js';
+
+const dirs: string[] = [];
+
+function executable(source: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'codor-grok-adapter-'));
+  dirs.push(dir);
+  const path = join(dir, 'fake-grok');
+  writeFileSync(path, `#!/usr/bin/env node\n${source}`);
+  chmodSync(path, 0o755);
+  return path;
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('Grok subprocess and capability conformance', () => {
+  it('maps documented effort and approval controls', () => {
+    expect(grokApprovalArgs('read-only')).toEqual([]);
+    expect(grokApprovalArgs('workspace-write')).toEqual([]);
+    expect(grokApprovalArgs('full-access')).toEqual(['--always-approve']);
+    expect(() => grokApprovalArgs('plan')).toThrow('valid policies');
+    expect(grokArgs({ harness: 'grok', cwd: '/work', session_ref: 'session', model: 'grok-4.5', policy: 'full-access', thinking: 'high' }, 'go'))
+      .toEqual([
+        '-p', 'go', '--output-format', 'streaming-json', '--no-auto-update',
+        '--model', 'grok-4.5', '--effort', 'high', '--always-approve', '--resume', 'session',
+      ]);
+  });
+
+  it('passes headless arguments and translates a streaming turn', async () => {
+    const command = executable(`
+const fs = require('node:fs');
+const input = fs.readFileSync(0, 'utf8');
+console.log(JSON.stringify({type:'session.started',session_id:'22222222-2222-4222-8222-222222222222'}));
+console.log(JSON.stringify({type:'response.output_text.delta',delta:JSON.stringify({argv:process.argv.slice(2),cwd:process.cwd(),input})}));
+console.log(JSON.stringify({type:'response.completed',status:'completed',usage:{input_tokens:2,output_tokens:3}}));
+`);
+    const adapter = new GrokAdapter(command);
+    const cwd = mkdtempSync(join(tmpdir(), 'codor-grok-cwd-'));
+    dirs.push(cwd);
+    const session = adapter.spawn({ cwd, model: 'grok-4.5', policy: 'read-only', thinking: 'medium' });
+    const events: WireEvent[] = [];
+    for await (const event of adapter.deliver(session, 'PONG')) events.push(event);
+    const done = events.at(-1) as Extract<WireEvent, { type: 'run.completed' }>;
+    expect(done).toMatchObject({ type: 'run.completed', status: 'completed', usage: { input_tokens: 2, output_tokens: 3 } });
+    expect(JSON.parse(done.final_text!)).toEqual({
+      argv: ['-p', 'PONG', '--output-format', 'streaming-json', '--no-auto-update', '--model', 'grok-4.5', '--effort', 'medium'],
+      cwd,
+      input: '',
+    });
+    expect(session.session_ref).toBe('22222222-2222-4222-8222-222222222222');
+  });
+
+  it('discovers UUID sessions from ~/.grok/sessions', () => {
+    const home = mkdtempSync(join(tmpdir(), 'codor-grok-home-'));
+    dirs.push(home);
+    mkdirSync(join(home, 'sessions', '44444444-4444-4444-8444-444444444444'), { recursive: true });
+    mkdirSync(join(home, 'sessions', 'not-a-session'), { recursive: true });
+    expect(new GrokAdapter('grok', home).discoverSessions())
+      .toEqual(['44444444-4444-4444-8444-444444444444']);
+  });
+
+  it('turns missing commands into failed runs', async () => {
+    const events: WireEvent[] = [];
+    for await (const event of new GrokAdapter('/definitely/missing/codor-grok').deliver(
+      new GrokAdapter().spawn({ cwd: process.cwd() }), 'hello')) events.push(event);
+    expect(events.at(-1)).toMatchObject({ type: 'run.completed', status: 'failed' });
+  });
+});

--- a/packages/adapters/grok/src/adapter.ts
+++ b/packages/adapters/grok/src/adapter.ts
@@ -1,0 +1,203 @@
+import { type ChildProcess } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { createInterface } from 'node:readline';
+import spawn from 'cross-spawn';
+
+import type {
+  AdapterTurnHooks,
+  HarnessAdapter,
+  ModelCatalog,
+  Session,
+  SessionRef,
+  SpawnOpts,
+  WireEvent,
+} from '@codor/protocol';
+import { PolicySchema } from '@codor/protocol';
+
+import { createTurnTranslator } from './translate.js';
+
+export function grokApprovalArgs(policy: string | undefined): string[] {
+  if (policy === undefined) return [];
+  if (!PolicySchema.safeParse(policy).success) {
+    throw new Error(`unknown policy '${policy}'; valid policies: ${PolicySchema.options.join(', ')}`);
+  }
+  return policy === 'full-access' ? ['--always-approve'] : [];
+}
+
+// harn:assume canonical-spawn-controls-enforced ref=grok-spawn-control-mapping
+export function grokArgs(session: Session, payload: string): string[] {
+  const args = ['-p', payload, '--output-format', 'streaming-json', '--no-auto-update'];
+  if (session.model !== undefined) args.push('--model', session.model);
+  if (session.thinking !== undefined) args.push('--effort', session.thinking);
+  args.push(...grokApprovalArgs(session.policy));
+  if (session.session_ref !== undefined) args.push('--resume', session.session_ref);
+  return args;
+}
+
+const SESSION_REF = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/** Direct `grok` headless CLI driver. See NOTES.md for the behavioral sources. */
+export class GrokAdapter implements HarnessAdapter {
+  readonly id = 'grok';
+  readonly capabilities = {
+    resume: true,
+    discover: true,
+    interactiveAttach: true,
+    ask: false,
+    approvals: 'spawn-time',
+    extensions: false,
+    thinking: true,
+    thinking_levels: ['low', 'medium', 'high'] as const,
+    // harn:assume live-inbox-capability-is-evidence-backed-v2 ref=grok-live-inbox-capability
+    live_inbox: false,
+    // Grok exposes --always-approve, but its CLI does not document a native
+    // read-only/workspace-write mapping. Do not imply either tier is enforced.
+    policies: {
+      'read-only': null,
+      'workspace-write': null,
+      'full-access': '--always-approve',
+    },
+    // harn:end live-inbox-capability-is-evidence-backed-v2
+  } as const;
+
+  private readonly children = new WeakMap<Session, ChildProcess>();
+
+  constructor(
+    private readonly command = 'grok',
+    private readonly home = join(homedir(), '.grok'),
+  ) {}
+
+  spawn(opts: SpawnOpts): Session {
+    grokApprovalArgs(opts.policy);
+    if (opts.thinking !== undefined &&
+      !(this.capabilities.thinking_levels as readonly string[]).includes(opts.thinking)) {
+      throw new Error(
+        `adapter 'grok' does not support thinking level '${opts.thinking}'; ` +
+        `valid levels: ${this.capabilities.thinking_levels.join(', ')}`,
+      );
+    }
+    return {
+      harness: this.id,
+      cwd: opts.cwd,
+      model: opts.model,
+      policy: opts.policy,
+      thinking: opts.thinking,
+    };
+  }
+
+  listModels(): Promise<ModelCatalog> {
+    return Promise.resolve({ models: ['grok-4.5'], source: 'curated' });
+  }
+
+  attach(session_ref: SessionRef): Session {
+    return { harness: this.id, session_ref, cwd: process.cwd() };
+  }
+
+  // harn:assume windows-cli-adapters-resolve-command-shims ref=windows-cli-spawn-provider
+  // harn:assume remaining-cli-adapters-use-supervised-subprocesses ref=grok-cli-subprocess-driver
+  // harn:assume adapter-process-lifecycle-supervised ref=grok-cli-process-supervision
+  async *deliver(
+    session: Session,
+    payload: string,
+    hooks: AdapterTurnHooks = {},
+  ): AsyncIterable<WireEvent> {
+    const args = grokArgs(session, payload);
+    const child = spawn(this.command, args, {
+      cwd: session.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: true,
+      env: { ...process.env, ...session.env },
+    });
+    this.children.set(session, child);
+
+    let stderr = '';
+    child.stderr!.setEncoding('utf8');
+    child.stderr!.on('data', (chunk: string) => {
+      stderr = `${stderr}${chunk}`.slice(-8192);
+    });
+    let childError: Error | undefined;
+    const spawned = new Promise<void>((resolve, reject) => {
+      child.once('spawn', resolve);
+      child.once('error', (error) => {
+        childError = error;
+        reject(error);
+      });
+    });
+    const closed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+      (resolve) => child.once('close', (code, signal) => resolve({ code, signal })),
+    );
+
+    const translator = createTurnTranslator(session.session_ref);
+    const reportSessionRef = (): void => {
+      const discovered = translator.sessionId();
+      if (discovered === undefined || discovered === session.session_ref) return;
+      session.session_ref = discovered;
+      hooks.onSessionRef?.(discovered);
+    };
+
+    try {
+      try {
+        await spawned;
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        yield* translator.end({ status: 'failed', final_text: detail });
+        return;
+      }
+      hooks.onStarted?.({ pid: child.pid, process_group_id: child.pid });
+      if (session.session_ref !== undefined) hooks.onSessionRef?.(session.session_ref);
+
+      const lines = createInterface({ input: child.stdout! });
+      for await (const line of lines) {
+        for (const event of translator.push(line)) {
+          reportSessionRef();
+          yield event;
+        }
+        reportSessionRef();
+      }
+      const exit = await closed;
+      const failed = childError !== undefined || (exit.code !== null && exit.code !== 0);
+      const detail = stderr.trim() || childError?.message;
+      yield* translator.end({
+        status: failed ? 'failed' : 'interrupted',
+        ...(detail !== undefined && detail !== '' && { final_text: detail }),
+      });
+    } finally {
+      this.children.delete(session);
+      if (child.exitCode === null && child.signalCode === null) this.signal(child, 'SIGKILL');
+    }
+  }
+
+  interrupt(session: Session): void {
+    const child = this.children.get(session);
+    if (child) this.signal(child, 'SIGINT');
+  }
+
+  private signal(child: ChildProcess, signal: NodeJS.Signals): void {
+    if (child.pid === undefined) return;
+    try {
+      process.kill(-child.pid, signal);
+    } catch {
+      child.kill(signal);
+    }
+  }
+
+  respondInteraction(): Promise<void> {
+    return Promise.reject(
+      new Error('grok headless streaming-json exposes no interaction response channel'),
+    );
+  }
+
+  discoverSessions(): SessionRef[] {
+    let entries;
+    try {
+      entries = readdirSync(join(this.home, 'sessions'), { withFileTypes: true });
+    } catch {
+      return [];
+    }
+    return entries
+      .filter((entry) => SESSION_REF.test(entry.name))
+      .map((entry) => entry.name);
+  }
+}

--- a/packages/adapters/grok/src/fixtures.spec.ts
+++ b/packages/adapters/grok/src/fixtures.spec.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import { createTurnTranslator } from './translate.js';
+
+describe('native Grok streaming-json fixture', () => {
+  it('translates text, thought, session id, and end events', () => {
+    const translator = createTurnTranslator();
+    const lines = readFileSync(new URL('../fixtures/streaming-native.jsonl', import.meta.url), 'utf8')
+      .trim().split('\n');
+    const events = lines.flatMap((line) => translator.push(line));
+
+    expect(events).toEqual([
+      { type: 'run.item', item_type: 'text_delta', payload: { text: 'hello ' } },
+      { type: 'run.item', item_type: 'reasoning_summary', payload: { text: 'checking the answer' } },
+      { type: 'run.item', item_type: 'text_delta', payload: { text: 'world' } },
+      { type: 'run.completed', status: 'completed', final_text: 'hello world' },
+    ]);
+    expect(translator.sessionId()).toBe('22222222-2222-4222-8222-222222222222');
+    expect(translator.end()).toEqual([]);
+  });
+});

--- a/packages/adapters/grok/src/index.spec.ts
+++ b/packages/adapters/grok/src/index.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { GrokAdapter } from './index.js';
+
+describe('@codor/adapter-grok barrel', () => {
+  it('exposes the conservative native capability contract', () => {
+    const adapter = new GrokAdapter();
+    expect(adapter.id).toBe('grok');
+    expect(adapter.capabilities).toEqual({
+      resume: true,
+      discover: true,
+      interactiveAttach: true,
+      ask: false,
+      approvals: 'spawn-time',
+      extensions: false,
+      thinking: true,
+      thinking_levels: ['low', 'medium', 'high'],
+      live_inbox: false,
+      policies: {
+        'read-only': null,
+        'workspace-write': null,
+        'full-access': '--always-approve',
+      },
+    });
+  });
+});

--- a/packages/adapters/grok/src/index.ts
+++ b/packages/adapters/grok/src/index.ts
@@ -1,0 +1,10 @@
+import { GrokAdapter } from './adapter.js';
+
+export { GrokAdapter, grokArgs, grokApprovalArgs } from './adapter.js';
+export { createTurnTranslator } from './translate.js';
+export type { TurnTranslator } from './translate.js';
+
+/** Factory for the `--adapter grok=<module>` external-registration path. */
+export function createAdapter(_config: { id: string }): GrokAdapter {
+  return new GrokAdapter();
+}

--- a/packages/adapters/grok/src/translate.ts
+++ b/packages/adapters/grok/src/translate.ts
@@ -1,0 +1,208 @@
+import type { WireEvent } from '@codor/protocol';
+
+type JsonRecord = Record<string, unknown>;
+
+interface GrokEvent extends JsonRecord {
+  type?: string;
+  session_id?: string;
+  sessionId?: string;
+  subtype?: string;
+  delta?: string;
+  text?: string;
+  output_text?: string;
+  result?: string;
+  data?: unknown;
+  status?: string;
+  stopReason?: string;
+  usage?: JsonRecord;
+  response?: JsonRecord;
+}
+
+export interface TurnTranslator {
+  push(line: string): WireEvent[];
+  end(fallback?: { status: 'failed' | 'interrupted'; final_text?: string }): WireEvent[];
+  sessionId(): string | undefined;
+}
+
+const MAX_OUTPUT = 256 * 1024;
+
+function boundedOutput(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  const text = typeof value === 'string' ? value : JSON.stringify(value);
+  if (text === undefined || Buffer.byteLength(text) <= MAX_OUTPUT) return text;
+  const marker = '\n[output truncated at 256 KiB]';
+  const markerBytes = Buffer.byteLength(marker);
+  let prefix = Buffer.from(text).subarray(0, MAX_OUTPUT - markerBytes).toString('utf8');
+  while (Buffer.byteLength(prefix) + markerBytes > MAX_OUTPUT) prefix = prefix.slice(0, -1);
+  return `${prefix}${marker}`;
+}
+
+function record(value: unknown): JsonRecord | undefined {
+  return typeof value === 'object' && value !== null ? value as JsonRecord : undefined;
+}
+
+function stringField(value: unknown, ...keys: string[]): string | undefined {
+  const source = record(value);
+  if (source === undefined) return undefined;
+  for (const key of keys) {
+    if (typeof source[key] === 'string' && source[key] !== '') return source[key] as string;
+  }
+  return undefined;
+}
+
+function numberField(value: unknown, ...keys: string[]): number | undefined {
+  const source = record(value);
+  if (source === undefined) return undefined;
+  for (const key of keys) {
+    if (typeof source[key] === 'number' && Number.isFinite(source[key])) return source[key] as number;
+  }
+  return undefined;
+}
+
+function usageFrom(event: GrokEvent): { input_tokens: number; output_tokens: number } | undefined {
+  const usage = event.usage ?? event.response?.usage;
+  if (usage === undefined) return undefined;
+  const input = numberField(usage, 'input_tokens', 'inputTokens', 'prompt_tokens') ?? 0;
+  const output = numberField(usage, 'output_tokens', 'outputTokens', 'completion_tokens') ?? 0;
+  return input === 0 && output === 0 &&
+    numberField(usage, 'total_tokens', 'totalTokens') === undefined
+    ? undefined
+    : { input_tokens: input, output_tokens: output };
+}
+
+function textFrom(event: GrokEvent): string | undefined {
+  return stringField(event, 'delta', 'text', 'output_text', 'result', 'content') ??
+    (typeof event.data === 'string' ? event.data : undefined) ??
+    stringField(event.response, 'output_text', 'text', 'content');
+}
+
+function eventType(event: GrokEvent): string {
+  return event.type ?? event.subtype ?? '';
+}
+
+function isTerminal(type: string, event: GrokEvent): boolean {
+  return type === 'result' || type === 'done' || type === 'complete' ||
+    type === 'end' ||
+    type === 'response.completed' || type === 'response.failed' ||
+    type === 'turn.completed' || type === 'session.completed' ||
+    ['success', 'completed', 'failed', 'error'].includes(event.status ?? '');
+}
+
+// harn:assume grok-capability-truth ref=grok-event-translation
+/** Translate Grok's streaming-json/Responses-style events into WireEvents. */
+export function createTurnTranslator(initialSessionId?: string): TurnTranslator {
+  let sessionId = initialSessionId;
+  let finalText = '';
+  let streamError: string | undefined;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let hasUsage = false;
+  let terminal = false;
+
+  return {
+    sessionId: () => sessionId,
+
+    push(line: string): WireEvent[] {
+      if (line.trim() === '') return [];
+      let event: GrokEvent;
+      try {
+        event = JSON.parse(line) as GrokEvent;
+      } catch {
+        return [];
+      }
+
+      const discovered = stringField(event, 'session_id', 'sessionId');
+      if (discovered !== undefined) sessionId = discovered;
+      const type = eventType(event);
+      const usage = usageFrom(event);
+      if (usage !== undefined) {
+        inputTokens = usage.input_tokens;
+        outputTokens = usage.output_tokens;
+        hasUsage = true;
+      }
+
+      if (type === 'response.reasoning_summary_text.delta' || type === 'reasoning_delta' ||
+        type === 'reasoning' || type === 'thought') {
+        const text = textFrom(event) ?? '';
+        return text === '' ? [] : [{ type: 'run.item', item_type: 'reasoning_summary', payload: { text } }];
+      }
+
+      if (type === 'tool_call' || type === 'tool_use' || type === 'tool.started' ||
+        type === 'tool.execution_start') {
+        const tool = stringField(event, 'tool_name', 'toolName', 'name') ?? 'tool';
+        const callId = stringField(event, 'call_id', 'callId', 'tool_call_id', 'toolCallId') ?? `grok-${tool}`;
+        return [{
+          type: 'run.item',
+          item_type: 'tool_call',
+          payload: {
+            call_id: callId,
+            tool,
+            title: tool,
+            input: event.arguments ?? event.input ?? event.parameters ?? {},
+          },
+        }];
+      }
+
+      if (type === 'tool_result' || type === 'tool.completed' || type === 'tool.execution_complete') {
+        const callId = stringField(event, 'call_id', 'callId', 'tool_call_id', 'toolCallId') ?? 'grok-tool';
+        const failed = event.status === 'error' || event.status === 'failed' || event.success === false;
+        return [{
+          type: 'run.item',
+          item_type: 'tool_result',
+          payload: {
+            call_id: callId,
+            status: failed ? 'error' : 'ok',
+            output_text: boundedOutput(event.output ?? event.result ?? event.error),
+            raw: event,
+          },
+        }];
+      }
+
+      if (type === 'error' || type === 'response.error' || event.status === 'error' || event.status === 'failed') {
+        streamError = stringField(event, 'message', 'error', 'detail') ?? boundedOutput(event.error);
+        return streamError === undefined ? [] : [{
+          type: 'run.item',
+          item_type: 'tool_result',
+          payload: { call_id: 'grok-error', status: 'error', output_text: streamError, raw: event },
+        }];
+      }
+
+      if (type === 'response.output_text.delta' || type === 'text_delta' || type === 'assistant.message_delta' ||
+        type === 'message' || type === 'assistant' || type === 'text') {
+        const text = textFrom(event) ?? '';
+        if (text === '') return [];
+        finalText += text;
+        return [{ type: 'run.item', item_type: 'text_delta', payload: { text } }];
+      }
+
+      if (isTerminal(type, event)) {
+        terminal = true;
+        const text = finalText !== '' ? finalText : textFrom(event);
+        const status = event.status === 'failed' || event.status === 'error' || type === 'response.failed' ||
+          event.stopReason === 'Error' || event.stopReason === 'error'
+          ? 'failed'
+          : 'completed';
+        return [{
+          type: 'run.completed',
+          status,
+          ...(text !== undefined && text !== '' && { final_text: text }),
+          ...(hasUsage && { usage: { input_tokens: inputTokens, output_tokens: outputTokens } }),
+        }];
+      }
+      return [];
+    },
+
+    end(fallback = { status: 'interrupted' as const }): WireEvent[] {
+      if (terminal) return [];
+      terminal = true;
+      const resolvedText = fallback.final_text ?? (finalText || streamError);
+      return [{
+        type: 'run.completed',
+        status: fallback.status,
+        ...(resolvedText !== undefined && resolvedText !== '' && { final_text: resolvedText }),
+        ...(hasUsage && { usage: { input_tokens: inputTokens, output_tokens: outputTokens } }),
+      }];
+    },
+  };
+}
+// harn:end grok-capability-truth

--- a/packages/adapters/grok/tsconfig.json
+++ b/packages/adapters/grok/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.spec.ts"]
+}

--- a/packages/cli/src/artifact.spec.ts
+++ b/packages/cli/src/artifact.spec.ts
@@ -26,6 +26,7 @@ const EXPECTED_CLOSURE = [
   '@codor/adapter-copilot',
   '@codor/adapter-cursor',
   '@codor/adapter-gemini',
+  '@codor/adapter-grok',
   '@codor/adapter-opencode',
   '@codor/cli',
   '@codor/protocol',
@@ -55,7 +56,7 @@ describe('artifact graph', () => {
     const direct = Object.keys(workspace.get(ENTRY_PACKAGE)?.manifest.dependencies ?? {});
     expect(direct.some((name) => name.startsWith('@codor/adapter-'))).toBe(false);
     expect(discoverClosure(workspace).filter((name) => name.startsWith('@codor/adapter-')))
-      .toHaveLength(8);
+      .toHaveLength(9);
   });
 
   it('rejects conflicting third-party dependency ranges', () => {

--- a/packages/cli/src/attach.ts
+++ b/packages/cli/src/attach.ts
@@ -53,6 +53,12 @@ export const nativeResumeCommand: InteractiveCommandResolver = (member, env) => 
       args: ['--resume', member.session_ref],
     };
   }
+  if (member.harness === 'grok') {
+    return {
+      command: env.CODOR_GROK_COMMAND ?? 'grok',
+      args: ['--resume', member.session_ref],
+    };
+  }
   throw new Error(`adapter '${member.harness ?? 'unknown'}' has no interactive resume command`);
 };
 

--- a/packages/cli/src/index.spec.ts
+++ b/packages/cli/src/index.spec.ts
@@ -810,6 +810,20 @@ describe('@codor/cli', () => {
     });
   });
 
+  it('resolves Grok interactive resume through the supervised attach path', () => {
+    expect(nativeResumeCommand({
+      id: 'grok-member',
+      kind: 'agent',
+      handle: 'grok',
+      display_name: 'Grok',
+      harness: 'grok',
+      session_ref: '44444444-4444-4444-8444-444444444444',
+    }, { CODOR_GROK_COMMAND: '/opt/grok' })).toEqual({
+      command: '/opt/grok',
+      args: ['--resume', '44444444-4444-4444-8444-444444444444'],
+    });
+  });
+
   it('spawns, posts, and tails through the unix WebSocket protocol', async () => {
     await cli('channels');
     expect(output).toContain('eng\tEngineering');

--- a/packages/switchboard/package.json
+++ b/packages/switchboard/package.json
@@ -25,6 +25,7 @@
     "@codor/adapter-copilot": "workspace:*",
     "@codor/adapter-cursor": "workspace:*",
     "@codor/adapter-gemini": "workspace:*",
+    "@codor/adapter-grok": "workspace:*",
     "@codor/adapter-opencode": "workspace:*",
     "@codor/protocol": "workspace:*",
     "better-sqlite3": "^12.11.1",

--- a/packages/switchboard/src/adapter-registry.spec.ts
+++ b/packages/switchboard/src/adapter-registry.spec.ts
@@ -18,7 +18,7 @@ describe('built-in executable registry', () => {
   it('keeps the approved canonical executable mapping beside built-in composition', () => {
     expect(BUILTIN_ADAPTER_EXECUTABLES).toEqual({
       antigravity: 'agy', 'claude-code': 'claude', codex: 'codex', copilot: 'copilot',
-      cursor: 'cursor-agent', gemini: 'gemini', opencode: 'opencode',
+      cursor: 'cursor-agent', gemini: 'gemini', grok: 'grok', opencode: 'opencode',
     });
   });
 
@@ -64,6 +64,7 @@ describe('adapter registry spawn controls', () => {
         ['copilot', false],
         ['cursor', false],
         ['gemini', false],
+        ['grok', false],
         ['opencode', false],
       ]);
   });
@@ -84,6 +85,7 @@ describe('adapter registry spawn controls', () => {
       ['copilot', false, undefined],
       ['cursor', false, undefined],
       ['gemini', false, undefined],
+      ['grok', true, ['low', 'medium', 'high']],
       ['opencode', true, ['low', 'medium', 'high']],
     ]);
   });
@@ -144,7 +146,7 @@ describe('the registry wrapper preserves the whole adapter contract', () => {
     const adapters = await loadAdapterRegistry();
     const answering = adapters.filter((adapter) => adapter.listModels !== undefined);
     expect(answering.map((adapter) => adapter.id).sort()).toEqual(
-      ['antigravity', 'claude-code', 'codex', 'copilot', 'gemini', 'opencode'],
+      ['antigravity', 'claude-code', 'codex', 'copilot', 'gemini', 'grok', 'opencode'],
     );
 
     const claude = adapters.find((adapter) => adapter.id === 'claude-code')!;

--- a/packages/switchboard/src/adapter-registry.ts
+++ b/packages/switchboard/src/adapter-registry.ts
@@ -9,6 +9,7 @@ import { CodexAdapter } from '@codor/adapter-codex';
 import { CopilotAdapter } from '@codor/adapter-copilot';
 import { CursorAdapter } from '@codor/adapter-cursor';
 import { GeminiAdapter } from '@codor/adapter-gemini';
+import { GrokAdapter } from '@codor/adapter-grok';
 import { OpenCodeAdapter } from '@codor/adapter-opencode';
 import {
   type AdapterCapabilities,
@@ -53,6 +54,7 @@ const builtinDefinitions: Record<string, {
   copilot: { executable: 'copilot', create: () => new CopilotAdapter() },
   cursor: { executable: 'cursor-agent', create: () => new CursorAdapter() },
   gemini: { executable: 'gemini', create: () => new GeminiAdapter() },
+  grok: { executable: 'grok', create: () => new GrokAdapter() },
   opencode: { executable: 'opencode', create: () => new OpenCodeAdapter() },
 };
 

--- a/packages/switchboard/src/pricing.spec.ts
+++ b/packages/switchboard/src/pricing.spec.ts
@@ -54,6 +54,22 @@ describe('estimateCostUsd', () => {
     })).toBeCloseTo(0.980004, 9);
   });
 
+  it('uses the published Grok 4.5 token rates', () => {
+    expect(estimateCostUsd('grok-4.5', {
+      input_tokens: 100_000,
+      output_tokens: 10_000,
+    })).toBeCloseTo(0.26, 9);
+    expect(estimateCostUsd('grok-4.5', {
+      input_tokens: 200_000,
+      output_tokens: 10_000,
+    })).toBeCloseTo(0.92, 9);
+    expect(estimateCostUsd('grok-4.5', {
+      input_tokens: 200_000,
+      cached_input_tokens: 100_000,
+      output_tokens: 10_000,
+    })).toBeCloseTo(0.58, 9);
+  });
+
   it('retains the retired Gemini Pro spelling only as stored-history compatibility', () => {
     const usage = { input_tokens: 10_000, output_tokens: 1_000 };
     expect(estimateCostUsd('gemini-3-pro-preview', usage))

--- a/packages/switchboard/src/pricing.ts
+++ b/packages/switchboard/src/pricing.ts
@@ -9,6 +9,7 @@
  * - https://developers.openai.com/api/docs/models/gpt-5.5
  * - https://ai.google.dev/gemini-api/docs/pricing
  * - https://ai.google.dev/gemini-api/docs/changelog
+ * - https://docs.x.ai/developers/models
  *
  * OpenAI uses its higher full-request rate when input exceeds 272K tokens.
  * Gemini 3.1 Pro Preview and 2.5 Pro use their higher full-request rate when
@@ -24,7 +25,7 @@ export interface TokenRate {
 
 export interface ModelPrice {
   standard: TokenRate;
-  longContext?: TokenRate & { aboveInputTokens: number };
+  longContext?: TokenRate & { aboveInputTokens: number; inclusive?: boolean };
 }
 
 const MILLION = 1_000_000;
@@ -81,6 +82,16 @@ export const MODEL_PRICES: Readonly<Record<string, ModelPrice>> = {
   'gemini-2.5-flash': {
     standard: { inputPerMTok: 0.3, outputPerMTok: 2.5 },
   },
+  'grok-4.5': {
+    standard: { inputPerMTok: 2, outputPerMTok: 6 },
+    longContext: {
+      aboveInputTokens: 200_000,
+      inclusive: true,
+      inputPerMTok: 4,
+      cachedInputPerMTok: 0.6,
+      outputPerMTok: 12,
+    },
+  },
 };
 
 const MODEL_ALIASES: Readonly<Record<string, string>> = {
@@ -100,7 +111,10 @@ export function estimateCostUsd(
 ): number | undefined {
   const price = priceForModel(model);
   if (price === undefined) return undefined;
-  const rate = price.longContext !== undefined && usage.input_tokens > price.longContext.aboveInputTokens
+  const rate = price.longContext !== undefined && (
+    usage.input_tokens > price.longContext.aboveInputTokens ||
+    (price.longContext.inclusive === true && usage.input_tokens >= price.longContext.aboveInputTokens)
+  )
     ? price.longContext
     : price.standard;
   const cachedInputTokens = Math.min(usage.cached_input_tokens ?? 0, usage.input_tokens);

--- a/packages/web-next/src/room/harness-marks.tsx
+++ b/packages/web-next/src/room/harness-marks.tsx
@@ -64,6 +64,12 @@ const MARKS: Record<string, HarnessMark> = {
       <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor" aria-hidden="true"><path d="M12 2c0 5.52-4.48 10-10 10 5.52 0 10 4.48 10 10 0-5.52 4.48-10 10-10-5.52 0-10-4.48-10-10Z"/></svg>
     ),
   },
+  'grok': {
+    label: 'Grok',
+    mark: (size: number) => (
+      <span className="nx-harness-monogram" style={{ width: size, height: size }} aria-hidden="true">G</span>
+    ),
+  },
   'antigravity': {
     label: 'Antigravity',
     // Antigravity does not publish a standalone product glyph in this repo;

--- a/packages/web-next/src/surfaces/LandingPage.tsx
+++ b/packages/web-next/src/surfaces/LandingPage.tsx
@@ -112,7 +112,7 @@ export function LandingPage() {
           </p>
           <div className="nx-tool-row" aria-label="Supported coding harnesses">
             <span>Claude Code</span><span>Codex</span><span>Cursor</span><span>Gemini CLI</span>
-            <span>OpenCode</span><span>GitHub Copilot</span><span>Antigravity</span>
+            <span>OpenCode</span><span>Grok</span><span>GitHub Copilot</span><span>Antigravity</span>
           </div>
         </div>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,19 @@ importers:
         specifier: ^6.0.6
         version: 6.0.6
 
+  packages/adapters/grok:
+    dependencies:
+      '@codor/protocol':
+        specifier: workspace:*
+        version: link:../../protocol
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
+    devDependencies:
+      '@types/cross-spawn':
+        specifier: ^6.0.6
+        version: 6.0.6
+
   packages/adapters/opencode:
     dependencies:
       '@codor/protocol':
@@ -193,6 +206,9 @@ importers:
       '@codor/adapter-gemini':
         specifier: workspace:*
         version: link:../adapters/gemini
+      '@codor/adapter-grok':
+        specifier: workspace:*
+        version: link:../adapters/grok
       '@codor/adapter-opencode':
         specifier: workspace:*
         version: link:../adapters/opencode

--- a/website/index.md
+++ b/website/index.md
@@ -30,7 +30,7 @@ pageClass: wr-landing-page
       <p class="wr-kicker">One line, on the record</p>
       <h2 id="thesis-title">One channel. Every agent on the wire.</h2>
     </div>
-    <p>Claude Code, Codex, Gemini, Copilot, and OpenCode keep their native sessions and bounded context. Codor carries only explicit messages and references between them.</p>
+    <p>Claude Code, Codex, Gemini, Grok, Copilot, and OpenCode keep their native sessions and bounded context. Codor carries only explicit messages and references between them.</p>
   </section>
 
   <section class="wr-principles" aria-label="Product principles">


### PR DESCRIPTION
## Summary
- add native xAI Grok CLI adapter with streaming-json translation, sessions, resume, effort, and policy wiring
- register Grok in switchboard and CLI attach paths
- add pricing, capability, documentation, branding, fixtures, and focused tests

## Verification
- pnpm --filter @codor/adapter-grok test
- pnpm --filter @codor/adapter-grok build
- pnpm --filter @codor/switchboard build
- git diff --check

The adapter retains the reviewed curated Grok model catalog (grok-4.5). Model discovery is intentionally not included in this PR.