### PR TITLE
docs: document Tailscale HTTPS prerequisite, pnpm dlx limitation, and build-approval setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ The interactive setup checks this computer, prepares private files, asks how the
 connect, starts Codor, verifies the daemon, and prints a QR, URL, eight-character pairing code, and
 expiry. It never sends channel data through a Codor-hosted service.
 
+> [!NOTE]
+> On pnpm, install into a project rather than running `pnpm dlx @richhardry/codor install`. A tested
+> `pnpm dlx` install did not pick up the workspace `packageExtensions` and native build-approval
+> settings this install needs—see [Self-host: Prerequisites](docs/SELF-HOST.md#prerequisites) for
+> the settings.
+
 Preview without changing the host:
 
 ```sh
@@ -116,6 +122,17 @@ Install and sign in to at least one supported agent:
 Tailscale lets you open Codor privately from your phone, tablet, or another computer—without
 putting it on the public internet. [Install Tailscale](https://tailscale.com/download) and sign in
 on both devices with the same account.
+
+> [!IMPORTANT]
+> Before this works, HTTPS certificates must be enabled for your tailnet at
+> [the admin console](https://console.tailscale.com/admin/dns). Until then, `tailscale serve` waits
+> for you to complete that setup in a browser instead of returning—if `codor install` looks frozen
+> at "configuring Tailscale", this is why. Enabling HTTPS only authorizes certificate issuance;
+> running `tailscale serve` (as `codor install` does) then issues one, which publishes this
+> machine's `*.ts.net` name to the public
+> [Certificate Transparency](https://tailscale.com/docs/how-to/set-up-https-certificates) log—a
+> disclosure that can't be undone, even if you disable HTTPS again later. If you'd rather skip this,
+> choose "On this computer only" during setup—you can add Tailscale access later.
 
 `codor install` can publish Codor privately over Tailscale automatically. If you skipped that step,
 run:

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -34,9 +34,13 @@ no cloud ever holds content, encrypted or not.
 ### Tier 0 — tailnet only (recommended default)
 
 Switchboard binds its Tailscale IP; web/iPhone connect over WireGuard (`tailscale serve` gives
-HTTPS + certs for free; a Tailscale app connector adds custom-domain access with ACL grants for
-teams). No Codor-related traffic leaves the tailnet; transport encryption is WireGuard's. **Zero third-party infrastructure.** Limits: watch has no tailnet of its own (phone
-relays via WatchConnectivity), and no push when the phone app is cold (see §push).
+HTTPS + certs once your tailnet has HTTPS certificates enabled—a one-time authorization step at
+[the admin console](https://console.tailscale.com/admin/dns); running `tailscale serve` then issues
+this machine's certificate, which publishes its `*.ts.net` name to the public Certificate
+Transparency log, irreversibly; a Tailscale app connector adds custom-domain access with ACL grants
+for teams). No Codor-related traffic leaves the tailnet; transport encryption is WireGuard's. **Zero
+third-party infrastructure.** Limits: watch has no tailnet of its own (phone relays via
+WatchConnectivity), and no push when the phone app is cold (see §push).
 
 ### Tier 1 — serverless P2P (the walkie tier)
 

--- a/docs/SELF-HOST.md
+++ b/docs/SELF-HOST.md
@@ -14,6 +14,14 @@ machine. No hosted Codor component is required.
 - pnpm 10.9.0, selected by the repository's `packageManager` field through Corepack.
 - Optional: Tailscale for private HTTPS access from phones and other machines.
 
+On pnpm 10.1–10.25, `better-sqlite3`'s native build script needs approval via
+`onlyBuiltDependencies: [better-sqlite3]` in `pnpm-workspace.yaml` or the `package.json` `pnpm`
+field. On pnpm 10.26 and newer (including pnpm 11), that setting is `allowBuilds: { better-sqlite3:
+true }` in `pnpm-workspace.yaml`—`pnpm approve-builds` writes it interactively. Without approval,
+`pnpm install` reports `Ignored build scripts: better-sqlite3` and the service fails to start with
+no native binding. See [pnpm's settings reference](https://pnpm.io/settings) for the current option
+names.
+
 Never expose port 8137 directly to the public internet. The browser token is a bearer credential;
 use loopback plus Tailscale Serve, another authenticated private tunnel, or a hardened reverse
 proxy you operate.
@@ -34,6 +42,12 @@ side-effect-free preview. Unattended mutation requires both `--yes` and
 `--access localhost|tailscale`; installation never guesses remote exposure from detection alone.
 `npx @richhardry/codor setup` remains available as a backward-compatible alias.
 <!-- harn:end public-npx-install-is-primary-install -->
+
+On pnpm, install into a project (`pnpm add @richhardry/codor`) rather than
+`pnpm dlx @richhardry/codor install`. A tested `pnpm dlx` install did not pick up the workspace
+`packageExtensions` and native build-approval settings this install needs, including the
+`better-sqlite3` approval above—`pnpm dlx` does honor some workspace configuration (for example
+catalogs), but not this.
 
 <!-- harn:assume source-cli-installers-remain-idempotent-fallback ref=selfhost-windows-cli-installer -->
 For source development, clone a stable ref and use the checkout installer:
@@ -209,7 +223,22 @@ For development diagnostics only, the single repository-relative fallback is
 
 ## Private access with Tailscale
 
-For the common single-operator setup, keep Codor on loopback and let Tailscale terminate HTTPS:
+For the common single-operator setup, keep Codor on loopback and let Tailscale terminate HTTPS.
+
+**Prerequisite:** HTTPS certificates must be enabled for your tailnet at
+[the admin console](https://console.tailscale.com/admin/dns) before `tailscale serve` will work
+non-interactively. Until that's done, `tailscale serve` blocks waiting for you to complete
+enablement in a browser instead of returning—this is the cause if `codor install` appears to hang
+at "configuring Tailscale". Enabling HTTPS **authorizes** certificate issuance for the tailnet, and
+running `tailscale serve` (as `codor install` does) **issues** one: the device's fully qualified
+`*.ts.net` name is written into the public Certificate Transparency log. Tailscale randomizes the
+tailnet DNS name so the ledger doesn't reveal your organization, but device names are published as
+chosen, and CT entries cannot be withdrawn. The feature itself is reversible—`tailscale serve reset`
+or disabling HTTPS breaks reliance on it but does not revoke already-issued certificates—the public
+disclosure is not. See
+[Tailscale's HTTPS certificate docs](https://tailscale.com/docs/how-to/set-up-https-certificates)
+for the full mechanism. Choosing localhost-only access during `codor install` skips Tailscale
+entirely.
 
 ```sh
 tailscale serve --bg http://127.0.0.1:8137


### PR DESCRIPTION
## Summary

- Documents a previously-undocumented prerequisite: `tailscale serve` (which `codor install` runs when you choose Tailscale access) blocks on interactive HTTPS-consent if the tailnet hasn't enabled HTTPS certificates yet. With no timeout and captured stdout, this presents as `codor install` hanging forever at "configuring Tailscale". README.md and docs/SELF-HOST.md now state the prerequisite and the two steps that matter: enabling HTTPS for a tailnet only *authorizes* certificate issuance, while running `tailscale serve` actually *issues* one and publishes the device's `*.ts.net` name to the public Certificate Transparency log, irreversibly.
- Corrects docs/PRIVACY.md's Tier 0 description, which previously described HTTPS enablement alone as giving "certs for free" — collapsing the same two steps and reading as "nothing to configure".
- Documents that a tested `pnpm dlx @richhardry/codor install` did not pick up the workspace `packageExtensions` and native build-approval settings the install needs. Worded as the tested observation rather than a categorical claim, since `pnpm dlx` does honor some workspace configuration (e.g. catalogs) — README.md and docs/SELF-HOST.md now recommend installing into a project instead.
- Documents the `better-sqlite3` build-approval setting name, which differs by pnpm version: `onlyBuiltDependencies` on pnpm 10.1–10.25, `allowBuilds` on pnpm 10.26+ and pnpm 11.

Docs-only: `README.md`, `docs/SELF-HOST.md`, `docs/PRIVACY.md`. No code, `.harn/`, or instruction-file changes.

## Test plan

Run on Windows 11, pnpm 10.9.0 (the pinned `packageManager`):

- [x] `pnpm install --frozen-lockfile` — passed, lockfile up to date
- [x] `pnpm -r build` — passed, all 17 buildable workspace projects
- [x] `packages/cli`: `pnpm exec vitest run` (direct invocation — `pnpm --filter @codor/cli test` cannot spawn Vitest on Windows) — 4 files failed, 5 tests failed, 175 passed, 18 skipped. Matches the 5 known Windows baseline failures exactly (`artifact.spec.ts`, `index.spec.ts` ×2, `runtime-install.spec.ts`, `setup-tailscale.spec.ts`). Zero delta from this docs-only change.
- [ ] `pnpm -r test` — **not run**. On this Windows checkout it aborts in `packages/adapters/antigravity` before ever reaching `packages/cli`, independent of this change, so it cannot be used to validate a docs-only PR here. Reporting it as passing or as having run would misrepresent the gate.

Not independently verified: the Tailscale Serve hang itself was not reproduced by executing `serve --bg`, since publishing a Serve endpoint is an outward-facing, irreversible-disclosure action. The `CertDomains: null` precondition and the blocking-consent code path were confirmed; the mechanism is documented Tailscale behavior (https://tailscale.com/docs/how-to/set-up-https-certificates).