### PR TITLE
fix(cli): bound Tailscale Serve invocation and surface stdout in diagnostic

### DIFF
--- a/packages/cli/src/setup-tailscale.spec.ts
+++ b/packages/cli/src/setup-tailscale.spec.ts
@@ -105,4 +105,30 @@ describe('configureTailscaleServe', () => {
     expect(() => configureTailscaleServe('/usr/bin/tailscale', 'http://127.0.0.1:8137', () => 'no serve config'))
       .toThrow(/did not report a private HTTPS origin/);
   });
+
+  it('includes stdout in the diagnostic when serve --bg times out waiting for consent', () => {
+    // A tailnet with no HTTPS certificates enabled makes `serve --bg` block on an
+    // interactive consent prompt instead of failing; Tailscale prints that prompt,
+    // including the consent URL, to stdout rather than stderr.
+    const error = Object.assign(new Error('Command failed: /usr/bin/tailscale serve --bg http://127.0.0.1:8137'), {
+      stdout: 'To enable HTTPS Certificates for your tailnet, visit:\nhttps://login.tailscale.com/f/https',
+      killed: true,
+      signal: 'SIGTERM',
+    });
+    expect(() => configureTailscaleServe('/usr/bin/tailscale', 'http://127.0.0.1:8137', (_command, args) => {
+      if (args[0] === 'serve' && args[1] === '--bg') throw error;
+      return '';
+    })).toThrow(/https:\/\/login\.tailscale\.com\/f\/https/);
+  });
+
+  it('bounds the serve --bg call with a timeout but leaves serve status unbounded', () => {
+    const calls: Array<{ args: string[]; options: { timeoutMs?: number } | undefined }> = [];
+    configureTailscaleServe('/usr/bin/tailscale', 'http://127.0.0.1:8137', (_command, args, options) => {
+      calls.push({ args, options });
+      if (args.join(' ') === 'serve status') return 'https://host.tail-abc.ts.net (tailnet only)';
+      return '';
+    });
+    expect(calls[0]).toEqual({ args: ['serve', '--bg', 'http://127.0.0.1:8137'], options: { timeoutMs: 20_000 } });
+    expect(calls[1]).toEqual({ args: ['serve', 'status'], options: undefined });
+  });
 });

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -37,7 +37,7 @@ const HARNESSES = ['claude', 'codex', 'opencode', 'gemini', 'copilot', 'cursor-a
 const LAUNCH_AGENT_LABEL = 'app.codor.switchboard';
 
 export interface SetupOverrides {
-  exec?(command: string, args: string[]): string;
+  exec?(command: string, args: string[], options?: { timeoutMs?: number }): string;
   exists?(path: string): boolean;
   home?: string;
   kernelRelease?: string;
@@ -67,9 +67,14 @@ export interface SetupOptions {
   yes?: boolean;
 }
 
-const defaultExec = (command: string, args: string[]): string => execFileSync(command, args, {
+const defaultExec = (
+  command: string,
+  args: string[],
+  options: { timeoutMs?: number } = {},
+): string => execFileSync(command, args, {
   encoding: 'utf8',
   stdio: ['ignore', 'pipe', 'pipe'],
+  ...(options.timeoutMs === undefined ? {} : { timeout: options.timeoutMs }),
 }).trim();
 
 const defaultWhich = (command: string): string | undefined => {
@@ -381,23 +386,29 @@ export function tailscaleServeSupported(
 export function configureTailscaleServe(
   tailscalePath: string,
   localEndpoint: string,
-  exec: (command: string, args: string[]) => string,
+  exec: (command: string, args: string[], options?: { timeoutMs?: number }) => string,
 ): string {
-  // Preserve the full message and stderr: real permission/operator guidance often
-  // lands on a later line (the same class of bug fixed for launchctl). Node's
-  // command error often already embeds stderr in `message`, so never append the
-  // same block twice.
+  // Preserve the full message, stdout, and stderr: real permission/operator
+  // guidance often lands on a later line (the same class of bug fixed for
+  // launchctl), and Tailscale's own consent/admin-console prompt for Serve is
+  // printed to stdout rather than stderr. Node's command error often already
+  // embeds stderr in `message`, so never append the same block twice.
   const diagnostic = (error: unknown): string => {
-    const err = error as { message?: string; stderr?: string | Buffer };
+    const err = error as { message?: string; stderr?: string | Buffer; stdout?: string | Buffer };
     const message = err.message?.trim();
     const stderr = err.stderr?.toString().trim();
+    const stdout = err.stdout?.toString().trim();
     const parts = message === undefined || message === '' ? [] : [message];
     if (stderr !== undefined && stderr !== '' && message?.includes(stderr) !== true) parts.push(stderr);
+    if (stdout !== undefined && stdout !== '' && message?.includes(stdout) !== true) parts.push(stdout);
     return parts.join('\n').trim() || String(error);
   };
   let status: string;
   try {
-    exec(tailscalePath, ['serve', '--bg', localEndpoint]);
+    // Bounded: when the tailnet has no HTTPS certificates enabled, `serve --bg`
+    // does not fail — it blocks waiting for interactive consent in a browser.
+    // `serve status` never blocks this way, so only the first call gets a budget.
+    exec(tailscalePath, ['serve', '--bg', localEndpoint], { timeoutMs: 20_000 });
     status = exec(tailscalePath, ['serve', 'status']);
   } catch (error) {
     throw new Error(`Tailscale Serve command failed: ${diagnostic(error)}`);


### PR DESCRIPTION
## Problem

`codor install`, after choosing "On this computer and remotely", can hang indefinitely at "configuring Tailscale" with no prompt, no error, no timeout, and no exit — the only recovery is Ctrl-C.

This happens when the tailnet does not have HTTPS certificates enabled. In that case `tailscale serve --bg` does not fail; it enters Tailscale's interactive feature-enablement flow, printing a consent URL to **stdout** and blocking until a human completes it in a browser. Two things in `configureTailscaleServe` (`setup.ts`) turn that into a silent freeze:

1. stdout is piped, not inherited, so the consent URL is captured into a buffer nobody sees;
2. no timeout is passed to `execFileSync`, so the wait is unbounded.

## Fix

- Bound only the `serve --bg` invocation with a 20s timeout. `serve status` (the next call, which never blocks this way) stays unbounded, and every other `defaultExec` caller is unaffected since the new `options` parameter is optional — verified by adding it to the shared `exec` type rather than special-casing one call site.
- Surface `stdout` alongside `stderr` in the thrown diagnostic, so a bounded failure explains itself instead of surfacing as a bare timeout.

Both changes are scoped to `configureTailscaleServe` and the shared `exec` signature; `defaultExec`'s behavior is unchanged for every other call site (`plutil`, `launchctl`, `wslinfo`, `icacls`, `systemctl`, `loginctl`, `schtasks`, `where`/`which`).

## Not in this PR

Preflighting the actual precondition (checking `CertDomains` via `tailscale status --json` before ever calling Serve, to turn the 20s wait into an immediate message) is a larger, separately-reviewable change that adds a dependency on a Tailscale JSON field. Proposing it as a follow-up once this lands.

## Testing

```powershell
pnpm install --frozen-lockfile
pnpm -r build
cd packages/cli
pnpm exec vitest run
```

Result: same 5 pre-existing failures as the unmodified baseline at this commit (`runtime-install.spec.ts:116`, `setup-tailscale.spec.ts` › `resolveTailscale`, two POSIX-path/JSON-escaping failures and a timeout in `index.spec.ts`, one unrelated `artifact.spec.ts` assertion) — all pnpm-11/Windows-path portability issues unrelated to this change. 177 passed (was 175), the 2 new tests in `setup-tailscale.spec.ts` both pass, no new failures.

`pnpm exec vitest run` is used directly rather than `pnpm --filter @codor/cli test` / `pnpm -r test`, which currently cannot reach or complete on Windows for unrelated reasons at this commit.

**Not independently reproduced:** the hang itself was not triggered by actually executing `tailscale serve --bg` — doing so publishes an endpoint to a tailnet and issues a publicly-logged HTTPS certificate, which is an irreversible disclosure. The blocking-consent mechanism is documented Tailscale behavior, confirmed by a second reviewer against `tailscale` v1.98.9 (`ipn/ipnlocal/serve_legacy.go`, `enableFeatureInteractive`). The preconditions codor checks (`CertDomains: null`, `BackendState: Running`, `Health: []`, `serve --help` exits 0) were all verified on the affected machine (Windows 11, Tailscale 1.98.9). Only tested on Windows 11; the macOS/Linux paths through this function are unchanged but not independently re-verified here.

## Harn

Touches the `setup-resolves-and-capability-probes-tailscale-serve` assumption (`setup.ts`, "Setup resolves Tailscale by path and app location and probes Serve support"). The assumption's substance is unchanged — Tailscale is still resolved and probed the same way; this only bounds and better-diagnoses the subsequent Serve call.