### PR TITLE
fix(cli): make the Windows CLI test gate runnable and green

### DIFF
--- a/packages/cli/src/artifact.spec.ts
+++ b/packages/cli/src/artifact.spec.ts
@@ -154,7 +154,12 @@ describe('built public artifact', () => {
     expect(readFileSync(join(cliRoot, 'runtime', 'web', 'index.html'), 'utf8')).toContain('<!doctype html>');
     expect(readFileSync(join(cliRoot, 'packaging', 'systemd', 'codor.service'), 'utf8'))
       .toContain('ExecStart=');
-    expect(statSync(join(outDir, 'bin', 'codor.mjs')).mode & 0o111).not.toBe(0);
+    // Windows has no POSIX executable permission bit — writeFileSync's `mode`
+    // option cannot set one there, so this property only exists to check on
+    // platforms where the filesystem tracks it.
+    if (process.platform !== 'win32') {
+      expect(statSync(join(outDir, 'bin', 'codor.mjs')).mode & 0o111).not.toBe(0);
+    }
   });
 
   it('contains no source, specs, fixtures, symlinks, or workspace protocols', () => {

--- a/packages/cli/src/artifact.spec.ts
+++ b/packages/cli/src/artifact.spec.ts
@@ -215,4 +215,21 @@ describe('CLI test environment isolation', () => {
       expect(String(failure.stderr)).not.toContain('never-print-this-value');
     }
   });
+
+  it('spawns a bare npm bin name by resolving its real entrypoint', () => {
+    // vitest in node_modules/.bin is a .CMD shim on Windows; this proves the
+    // wrapper resolves and runs it rather than spawning the bare name as-is.
+    const output = execFileSync(process.execPath, [wrapper, 'vitest', '--version'], { encoding: 'utf8' });
+    expect(output).toMatch(/^vitest\//);
+  });
+
+  it('falls back to spawning a bare non-package executable directly', () => {
+    // `node` names no npm package in this workspace; the wrapper must still
+    // spawn it directly rather than requiring a package.json bin entry.
+    const output = execFileSync(process.execPath, [wrapper, 'node', '-e', 'process.stdout.write("ok")'], {
+      encoding: 'utf8',
+      env: poisoned,
+    });
+    expect(output).toBe('ok');
+  });
 });

--- a/packages/cli/src/index.spec.ts
+++ b/packages/cli/src/index.spec.ts
@@ -1264,12 +1264,14 @@ describe('@codor/cli', () => {
     const fixtures = fileURLToPath(new URL('../fixtures/', import.meta.url));
     const claudeTranscript = join(dir, 'claude-transcript.jsonl');
     writeFileSync(
-      JSON.stringify(claudeTranscript).slice(1, -1),
+      claudeTranscript,
       readFileSync(join(fixtures, 'claude-transcript.jsonl'), 'utf8'),
     );
+    // JSON-escape the path before embedding it in a JSON string value — a raw
+    // Windows path's single backslashes are not valid JSON escape sequences.
     const claudeRaw = readFileSync(join(fixtures, 'claude-stop.json'), 'utf8').replace(
       'CLAUDE_TRANSCRIPT_PATH',
-      claudeTranscript,
+      JSON.stringify(claudeTranscript).slice(1, -1),
     );
     expect(parseMirrorHook('claude', claudeRaw)).toMatchObject({
       type: 'mirror_turn',
@@ -1314,6 +1316,9 @@ describe('@codor/cli', () => {
 
   // harn:assume empty-database-desk-uses-service-home ref=bootstrap-service-home-regression
   // harn:assume empty-database-desk-seeds-tutorial-atomically ref=bootstrap-tutorial-regression
+  // Two full startCodor/close cycles plus native module load routinely exceed
+  // vitest's 5s default on Windows, where process and filesystem overhead is
+  // higher than on POSIX; this does not indicate a hang (observed ~6s).
   it('bootstraps one home-rooted Desk and one durable Tutorial message', async () => {
     const homeDir = join(dir, 'service-home');
     mkdirSync(homeDir);
@@ -1407,7 +1412,7 @@ describe('@codor/cli', () => {
     } finally {
       await restarted.close();
     }
-  });
+  }, 15000);
   // harn:end empty-database-desk-seeds-tutorial-atomically
   // harn:end empty-database-desk-uses-service-home
 

--- a/packages/cli/src/runtime-install.spec.ts
+++ b/packages/cli/src/runtime-install.spec.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, sep } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -12,7 +12,10 @@ import {
 } from './runtime-install.js';
 import { type RuntimePaths } from './runtime-paths.js';
 
-const HOME = '/home/u';
+// Built through `resolve()`, the same call the code under test makes on a
+// durable install root, so this fixture already carries a Windows drive
+// prefix where the implementation's own normalization would add one.
+const HOME = resolve(sep, 'home', 'u');
 const DATA = join(HOME, '.codor');
 const LOCATION = join(DATA, 'runtime');
 

--- a/packages/cli/src/setup-tailscale.spec.ts
+++ b/packages/cli/src/setup-tailscale.spec.ts
@@ -1,3 +1,5 @@
+import { resolve, sep } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import { configureTailscaleServe, resolveTailscale, tailscaleServeSupported } from './setup.js';
@@ -6,7 +8,10 @@ const APP_CLI = '/Applications/Tailscale.app/Contents/MacOS/Tailscale';
 
 describe('resolveTailscale', () => {
   it('returns the PATH hit when present', () => {
-    expect(resolveTailscale(() => '/usr/bin/tailscale', 'darwin', () => true)).toBe('/usr/bin/tailscale');
+    // resolveTailscale normalizes the PATH hit through resolve(); build the
+    // fixture the same way so the expectation matches on every platform.
+    const pathHit = resolve(sep, 'usr', 'bin', 'tailscale');
+    expect(resolveTailscale(() => pathHit, 'darwin', () => true)).toBe(pathHit);
   });
 
   it('falls back to the macOS app location when PATH misses but the app exists', () => {

--- a/scripts/test-env.mjs
+++ b/scripts/test-env.mjs
@@ -1,11 +1,29 @@
 #!/usr/bin/env node
 
 import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { dirname, isAbsolute, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
 
 const [command, ...args] = process.argv.slice(2);
 if (command === undefined) {
   process.stderr.write('usage: test-env.mjs <command> [args...]\n');
   process.exit(2);
+}
+
+// Resolve a bare package bin name (e.g. "vitest") to its real entrypoint and
+// run it under `node` directly, bypassing the platform-specific
+// node_modules/.bin shim (a .CMD file on Windows, which child_process.spawn
+// refuses to execute without `shell: true`). A command that already looks
+// like a path (e.g. an absolute executable path a caller resolved itself) is
+// spawned unchanged below.
+function resolveBinEntry(name) {
+  const packageJsonPath = require.resolve(`${name}/package.json`);
+  const pkg = require(packageJsonPath);
+  const bin = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin?.[name];
+  if (bin === undefined) throw new Error(`"${name}" declares no "${name}" bin entry (${packageJsonPath})`);
+  return join(dirname(packageJsonPath), bin);
 }
 
 // harn:assume cli-tests-delete-inherited-codor-environment ref=cli-test-environment-wrapper
@@ -16,7 +34,19 @@ if (removed.length > 0) {
   process.stderr.write(`test-env: removed ${String(removed.length)} inherited CODOR_ variable(s): ${removed.join(', ')}\n`);
 }
 
-const child = spawn(command, args, { stdio: 'inherit', env });
+const looksLikePath = command.includes('/') || command.includes('\\') || isAbsolute(command);
+let spawnCommand = command;
+let spawnArgs = args;
+if (!looksLikePath) {
+  try {
+    spawnCommand = process.execPath;
+    spawnArgs = [resolveBinEntry(command), ...args];
+  } catch (error) {
+    process.stderr.write(`test-env: failed to resolve ${command}: ${error.message}\n`);
+    process.exit(1);
+  }
+}
+const child = spawn(spawnCommand, spawnArgs, { stdio: 'inherit', env });
 child.on('error', (error) => {
   process.stderr.write(`test-env: failed to spawn ${command}: ${error.message}\n`);
   process.exitCode = 1;

--- a/scripts/test-env.mjs
+++ b/scripts/test-env.mjs
@@ -12,18 +12,25 @@ if (command === undefined) {
   process.exit(2);
 }
 
-// Resolve a bare package bin name (e.g. "vitest") to its real entrypoint and
-// run it under `node` directly, bypassing the platform-specific
+// Resolve a bare package bin name (e.g. "vitest") to its real entrypoint so
+// it can run under `node` directly, bypassing the platform-specific
 // node_modules/.bin shim (a .CMD file on Windows, which child_process.spawn
-// refuses to execute without `shell: true`). A command that already looks
-// like a path (e.g. an absolute executable path a caller resolved itself) is
-// spawned unchanged below.
+// refuses to execute without `shell: true`). Returns undefined for a bare
+// command that names no such package (e.g. a system executable like `node`
+// or `git`) — the caller falls back to spawning it directly, exactly as
+// before this resolution existed. A command that already looks like a path
+// (e.g. an absolute executable path a caller resolved itself) is spawned
+// unchanged below and never reaches this function.
 function resolveBinEntry(name) {
-  const packageJsonPath = require.resolve(`${name}/package.json`);
+  let packageJsonPath;
+  try {
+    packageJsonPath = require.resolve(`${name}/package.json`);
+  } catch {
+    return undefined;
+  }
   const pkg = require(packageJsonPath);
   const bin = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin?.[name];
-  if (bin === undefined) throw new Error(`"${name}" declares no "${name}" bin entry (${packageJsonPath})`);
-  return join(dirname(packageJsonPath), bin);
+  return bin === undefined ? undefined : join(dirname(packageJsonPath), bin);
 }
 
 // harn:assume cli-tests-delete-inherited-codor-environment ref=cli-test-environment-wrapper
@@ -35,17 +42,10 @@ if (removed.length > 0) {
 }
 
 const looksLikePath = command.includes('/') || command.includes('\\') || isAbsolute(command);
-let spawnCommand = command;
-let spawnArgs = args;
-if (!looksLikePath) {
-  try {
-    spawnCommand = process.execPath;
-    spawnArgs = [resolveBinEntry(command), ...args];
-  } catch (error) {
-    process.stderr.write(`test-env: failed to resolve ${command}: ${error.message}\n`);
-    process.exit(1);
-  }
-}
+const binEntry = looksLikePath ? undefined : resolveBinEntry(command);
+const [spawnCommand, spawnArgs] = binEntry === undefined
+  ? [command, args]
+  : [process.execPath, [binEntry, ...args]];
 const child = spawn(spawnCommand, spawnArgs, { stdio: 'inherit', env });
 child.on('error', (error) => {
   process.stderr.write(`test-env: failed to spawn ${command}: ${error.message}\n`);


### PR DESCRIPTION
## Problem

On Windows, the CLI package's own documented test command could not run at all, and even a direct Vitest invocation showed five failing tests unrelated to any of the behavioural changes proposed elsewhere. Contributors on Windows had no way to distinguish their own regressions from this pre-existing baseline. See `docs/issues/codor-install-issues.md` (Issue I, parts 1 and 2) in this fork for the full investigation this PR implements.

## What was wrong, and the fix

**`pnpm --filter @codor/cli test` aborted with `spawn vitest ENOENT`.** The wrapper at `scripts/test-env.mjs` spawned the given command name directly (`spawn(command, args, ...)`). On Windows, `vitest` in `node_modules/.bin` is a `.CMD` shim; `child_process.spawn` cannot execute a bare command name that only resolves to a `.CMD`/`.bat` file without `shell: true`, and enabling `shell: true` would put every test argument through cmd.exe's own quoting rules on a wrapper that exists to pass arguments through untouched.

Fix: resolve a bare package bin name (e.g. `vitest`) to its real JS entrypoint via the package's own `package.json` `bin` field, and run that under `node` directly — bypassing the platform-specific shim entirely, no shell involved. A bare command that names no such package (e.g. a system executable like `node` or `git`) falls back to being spawned directly, exactly as before this change. A command that already looks like a path (contains a separator, or is absolute — e.g. `process.execPath`, which the wrapper's own spec passes directly) is spawned unchanged too, since that case already worked and isn't the reported defect. (A first pass made bin-name resolution mandatory instead of a fallback, which regressed the bare-executable case — caught in review and corrected in the second commit, with regression coverage added for both paths.)

**Five CLI-suite tests then still failed**, each for its own reason (verified by direct reproduction, not assumed):

- `runtime-install.spec.ts` and `setup-tailscale.spec.ts`: both fixtures build a POSIX-shaped absolute path as a raw string literal (`/home/u`, `/usr/bin/tailscale`) and assert exact equality against it. The code under test (`packageRuntimePaths`, `resolveTailscale`) normalizes through `path.resolve()`, which on Windows drive-qualifies a rooted-but-driveless path (`/home/u` → `C:\home\u`). Fix: build the fixtures with `resolve(sep, ...)` too, so the expectation is constructed the same way the implementation constructs its result, on every platform — rather than special-casing the assertion for Windows.
- `index.spec.ts` ("parses documented Claude hooks..."): a real temp-file path (containing backslashes on Windows) was substituted unescaped into a JSON fixture string, which JSON.parse then rejected (`Bad escaped character in JSON`). Separately, the *actual* file write used a JSON-escaped (double-backslashed) form of that same path — harmless on Windows only because NTFS collapses repeated separators, but the reverse of what each call site needed. Fix: use the raw path for the real filesystem write, and the JSON-escaped form for the JSON-embedded copy.
- `index.spec.ts` ("bootstraps one home-rooted Desk..."): a real two-cycle server bootstrap (native module load, socket, HTTP) genuinely takes ~5.3-5.8s on this Windows machine, just over Vitest's 5s default — not a hang (confirmed by re-running with a raised timeout, where it consistently passes). Fix: extend this one test's timeout to 15s.
- `artifact.spec.ts`: asserted the built wrapper's file mode carries a POSIX executable permission bit. Windows/NTFS has no such concept — `writeFileSync(..., { mode: 0o755 })` verifiably produces `0o666` on Windows regardless (checked directly on this machine) — so the assertion cannot pass there and isn't testing anything meaningful on that platform. Fix: skip that one assertion on `win32`, keep it as-is elsewhere.

## Scope

This is Issue I, parts (1) and (2), from the linked investigation. It does **not** make `pnpm -r test` green — the recursive gate still stops in `packages/adapters/antigravity` before ever reaching `packages/cli` (Issue I, part 3: an `interrupted` vs `failed` adapter-event mismatch). That failure is unrelated to test infrastructure and was not diagnosed as part of this change; it may need its own issue.

## Harn

`CONTRIBUTING.md` notes a PR may be opened without Harn review, with the hard rule of never editing `.harn/assumptions/` directly — this PR does not. The four spec-file changes touch no behavioural assumption; they only make existing assertions match what the implementation actually does, on every platform. The `scripts/test-env.mjs` change sits inside the `cli-tests-delete-inherited-codor-environment` block (`ref=cli-test-environment-wrapper`). The assumption's substance is unaffected: it changes *how* the wrapper spawns its child process, not which `CODOR_*` variables it strips or when. Opened as a draft since this touches process-spawning behaviour.

## Testing

Windows 11, Node 26.2.0, pnpm 10.9.0 (the pinned `packageManager`). Commands and output below are the exact, current (post-review-fix) results.

```powershell
pnpm install --frozen-lockfile   # Lockfile is up to date, resolution step is skipped
pnpm -r build                    # Scope: 17 of 18 workspace projects; succeeds
cd packages/cli
pnpm test                        # now runs (previously: spawn vitest ENOENT)
# Test Files  16 passed | 2 skipped (18)
#      Tests  182 passed | 18 skipped (200)
```

Before this change, a direct Vitest invocation (`pnpm exec vitest run`, since `pnpm test` itself could not spawn Vitest) showed 5 failed / 175 passed / 18 skipped (198). After this change, `pnpm test` itself runs to completion and is fully green: the same 175 plus the previously-failing 5, plus 2 new regression tests added in the review-fix commit (bare npm-bin resolution and bare-executable fallback) — 182 passed / 18 skipped / 0 failed (200 total).

Also re-ran `pnpm -r test` after this change to confirm scope: it still aborts in `packages/adapters/antigravity` (`ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL`) and `packages/cli` still never runs under the recursive gate — confirming that gap is Issue I part (3), untouched by this PR.

**Not tested:** macOS and Linux. The `scripts/test-env.mjs` change is written to be a no-op in effect on POSIX (a bare `vitest` there already resolves and spawns correctly without a shim; this fix reroutes it through the same resolve-and-spawn-under-node path, which was manually reasoned through but not executed on that platform). If a POSIX reviewer can confirm `pnpm --filter @codor/cli test` still passes there, that closes the last gap.
