### PR TITLE
fix(cli): propagate NODE_PATH to the generated service, not just PATH

### DIFF
--- a/packages/cli/src/index.spec.ts
+++ b/packages/cli/src/index.spec.ts
@@ -334,6 +334,7 @@ describe('@codor/cli', () => {
       [dry-run] write /home/setup-test/.config/codor/env mode 600
       CODOR_TOKEN=<redacted generated-or-existing token>
       PATH=/home/setup-test/.local/bin:/home/setup-test/.nvm/versions/node/v22.8.0/bin:/home/setup-test/.opencode/bin:/usr/local/bin:/usr/bin
+      NODE_PATH=<repo>/node_modules/.pnpm/node_modules
       [dry-run] systemctl --user daemon-reload
       [dry-run] systemctl --user enable --now codor.service
       [dry-run] access localhost; skip Tailscale Serve
@@ -477,11 +478,60 @@ describe('@codor/cli', () => {
     // The service ExecStart references the durable ~/.codor/runtime copy, never the npx cache.
     expect(unit).toContain(`\"${durableCli}\"`);
     expect(unit).not.toContain('_npx');
+    // The stubbed installIo reports no pnpm hoist dir at the source root, so no
+    // NODE_PATH is derived — the negative case for the pnpm-linked detection.
+    expect(readFileSync(join(home, '.config', 'codor', 'env'), 'utf8')).not.toContain('NODE_PATH');
     // The durable install stages the npx module tree beside ~/.codor/runtime.
     expect(copies).toEqual([[
       join(dir, 'npx cache', '.npm', '_npx', 'deadbeef', 'node_modules'),
       join(`${join(home, '.codor', 'runtime')}.staging`, 'node_modules'),
     ]]);
+  });
+
+  it('derives NODE_PATH from the durable copy, not the ephemeral source, when the invoking runtime is ephemeral', async () => {
+    const sourceRoot = fileURLToPath(new URL('../../../', import.meta.url));
+    const home = join(dir, 'npx home nodepath');
+    const npxCacheRoot = join(dir, 'npx cache nodepath', '.npm', '_npx', 'deadbeef');
+    const npxCli = join(npxCacheRoot, 'node_modules', '@richhardry', 'codor', 'node_modules', '@codor', 'cli');
+    const sourceHoistDir = join(npxCacheRoot, 'node_modules', '.pnpm', 'node_modules');
+    await runCli(['node', 'codor', 'setup', '--yes', '--access', 'localhost'], {
+      env: { HOME: home, USER: 'setup-test', PATH: '/usr/bin' },
+      stdout: (line) => output.push(line),
+      setup: {
+        exec: () => '',
+        home,
+        nodePath: process.execPath,
+        platform: 'linux',
+        probe: async () => true,
+        randomToken: () => 'a'.repeat(64),
+        sleep: async () => undefined,
+        which: () => undefined,
+        runtime: {
+          root: npxCli,
+          layout: 'installed-package',
+          cliEntrypoint: join(npxCli, 'dist', 'index.js'),
+          staticRoot: join(npxCli, 'runtime', 'web'),
+          serviceTemplate: join(sourceRoot, 'packaging', 'systemd', 'codor.service'),
+        },
+        installIo: {
+          // The ephemeral source is pnpm-linked (unlike the sibling npx case
+          // above), so the positive derivation actually runs here.
+          exists: (path) => path.includes('.staging') || path === sourceHoistDir,
+          copyTree: () => undefined,
+          move: () => undefined,
+          remove: () => undefined,
+          readVersion: () => undefined,
+        },
+      },
+    });
+
+    const durableHoistDir = join(home, '.codor', 'runtime', 'node_modules', '.pnpm', 'node_modules');
+    const env = readFileSync(join(home, '.config', 'codor', 'env'), 'utf8');
+    // This is the case that fails if the probe is pointed at the destination
+    // instead of the source: NODE_PATH must be rooted at the durable copy the
+    // service will actually run from, never at the ephemeral npx cache path.
+    expect(env).toContain(`NODE_PATH=${durableHoistDir}`);
+    expect(env).not.toContain(npxCacheRoot);
   });
 
   // harn:assume wsl-setup-keeps-private-windows-loopback ref=wsl-bind-regression
@@ -658,6 +708,12 @@ describe('@codor/cli', () => {
     expect(readFileSync(envPath, 'utf8')).toContain(
       `PATH=${join(home, '.local', 'bin')}:/opt/node/bin:/usr/bin`,
     );
+    // repoRoot is this real checkout, which is pnpm-linked, so the hoisted
+    // dependency dir the durable copy will carry over is present and durable
+    // (repoRoot === serviceLocation for a source checkout).
+    expect(readFileSync(envPath, 'utf8')).toContain(
+      `NODE_PATH=${join(repoRoot, 'node_modules', '.pnpm', 'node_modules')}`,
+    );
     // Tailscale is resolved to an absolute path, capability-probed, and Serve is
     // published during Choose access — before the daemon is started.
     expect(commands).toEqual([
@@ -717,6 +773,11 @@ describe('@codor/cli', () => {
     expect(dryRunPlist).toContain('<string>&lt;redacted generated-or-existing token&gt;</string>');
     expect(dryRunPlist).toContain('<key>ProcessType</key>\n  <string>Background</string>');
     expect(dryRunPlist).toContain('<key>Umask</key>\n  <integer>63</integer>');
+    // repoRoot is this real checkout, which is pnpm-linked (source checkout,
+    // so repoRoot === serviceLocation), so NODE_PATH is emitted alongside PATH.
+    expect(dryRunPlist).toContain(
+      `<key>NODE_PATH</key>\n    <string>${join(repoRoot, 'node_modules', '.pnpm', 'node_modules')}</string>`,
+    );
 
     output = [];
     await runCli(['node', 'codor', 'setup', '--yes', '--access', 'localhost'], {
@@ -754,6 +815,9 @@ describe('@codor/cli', () => {
     expect(installedPlist).toContain(`${join(home, '.codor', 'logs', 'codor.err.log').replace('&', '&amp;')}</string>`);
     expect(installedPlist).toContain(
       `<string>${join(home, '.local', 'bin').replace('&', '&amp;')}:/opt/homebrew/bin:/Applications/Claude Code/bin:/opt/codor tools/bin:/usr/bin</string>`,
+    );
+    expect(installedPlist).toContain(
+      `<key>NODE_PATH</key>\n    <string>${join(repoRoot, 'node_modules', '.pnpm', 'node_modules')}</string>`,
     );
     expect(commands).toEqual([
       `plutil -lint ${launchAgentPath}`,

--- a/packages/cli/src/setup-win32.spec.ts
+++ b/packages/cli/src/setup-win32.spec.ts
@@ -55,6 +55,7 @@ describe('codor setup on Windows', () => {
       expect(rendered).toContain('<Hidden>true</Hidden>');
       expect(rendered).toContain('schtasks /Create');
       expect(rendered).not.toContain('a'.repeat(64));
+      expect(rendered).not.toContain('NODE_PATH');
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -89,6 +90,32 @@ describe('codor setup on Windows', () => {
       expect(commands).toContain(`schtasks /Create /TN Codor Switchboard /XML ${taskPath} /F`);
       expect(commands).toContain('schtasks /Run /TN Codor Switchboard');
       expect(output.join('\n')).not.toContain('a'.repeat(64));
+      expect(readFileSync(scriptPath, 'utf8')).not.toContain('NODE_PATH');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('emits NODE_PATH pointing at the pnpm hoist dir when the invoking runtime is pnpm-linked', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'codor-win32-nodepath-'));
+    const commands: string[] = [];
+    const output: string[] = [];
+    const home = join(root, 'home');
+    try {
+      const overrides = winOptions(root, commands, output);
+      const hoistDir = join(overrides.repoRoot, 'node_modules', '.pnpm', 'node_modules');
+      mkdirSync(hoistDir, { recursive: true });
+      await runSetup({
+        access: 'localhost',
+        dryRun: false,
+        env: { USERNAME: 'test-user', PATH: 'C:\\Windows\\System32' },
+        out: (line) => output.push(line),
+        overrides,
+        yes: true,
+      });
+      const scriptPath = join(home, '.config', 'codor', 'codor-service.ps1');
+      const script = readFileSync(scriptPath, 'utf8');
+      expect(script).toContain(`$env:NODE_PATH = '${hoistDir}'`);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -177,6 +177,7 @@ function xml(value: string): string {
 interface LaunchAgentOptions {
   dataDir: string;
   logDir: string;
+  nodeModulePath?: string;
   nodePath: string;
   runtime: RuntimePaths;
   servicePath: string;
@@ -196,6 +197,9 @@ function renderLaunchAgent(options: LaunchAgentOptions): string {
     staticRoot: xml(options.runtime.staticRoot),
     token: xml(options.token),
   };
+  const nodeModulePathEntry = options.nodeModulePath === undefined
+    ? ''
+    : `\n    <key>NODE_PATH</key>\n    <string>${xml(options.nodeModulePath)}</string>`;
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -223,7 +227,7 @@ function renderLaunchAgent(options: LaunchAgentOptions): string {
     <key>CODOR_TOKEN</key>
     <string>${values.token}</string>
     <key>PATH</key>
-    <string>${values.servicePath}</string>
+    <string>${values.servicePath}</string>${nodeModulePathEntry}
   </dict>
   <key>RunAtLoad</key>
   <true/>
@@ -557,6 +561,7 @@ export async function runRemoteAccess(deps: RemoteAccessDeps): Promise<RemoteAcc
 export function renderWindowsServiceScript(options: {
   dataDir: string;
   logDir: string;
+  nodeModulePath?: string;
   nodePath: string;
   runtime: RuntimePaths;
   servicePath: string;
@@ -568,6 +573,7 @@ export function renderWindowsServiceScript(options: {
   return [
     `$env:CODOR_TOKEN = (Get-Content -Raw -Path '${quote(options.tokenPath)}').Trim()`,
     `$env:PATH = '${quote(options.servicePath)}'`,
+    ...(options.nodeModulePath === undefined ? [] : [`$env:NODE_PATH = '${quote(options.nodeModulePath)}'`]),
     `Set-Location -Path '${quote(options.runtime.root)}'`,
     `& '${quote(options.nodePath)}' '${quote(entrypoint)}' --data-dir '${quote(options.dataDir)}' up --static-root '${quote(staticRoot)}' --channel desk --channel-name Desk >> '${quote(join(options.logDir, 'codor.out.log'))}' 2>> '${quote(join(options.logDir, 'codor.err.log'))}'`,
     'exit $LASTEXITCODE',
@@ -666,6 +672,14 @@ export async function runSetup(options: SetupOptions): Promise<void> {
   const installSource = resolveInstallSource(runtime);
   const serviceLocation = installSource.durable ? installSource.installRoot : durableRuntimeLocation(dataDir);
   const serviceRuntime = installSource.durable ? runtime : packageRuntimePaths(installedCliRoot(serviceLocation));
+  // pnpm's hidden hoist directory sits at a fixed offset inside a pnpm-linked
+  // tree and survives installDurableRuntime's wholesale node_modules copy.
+  // Probe the source root, which exists now, and emit the destination path,
+  // which is where the service will actually run once installed.
+  const hoistDirRelative = join('node_modules', '.pnpm', 'node_modules');
+  const nodeModulePath = installIo.exists(join(installSource.installRoot, hoistDirRelative))
+    ? join(serviceLocation, hoistDirRelative)
+    : undefined;
   const windowsScriptPath = join(configDir, 'codor-service.ps1');
   const windowsTaskPath = join(configDir, 'codor-task.xml');
   const windowsUser = options.env.USERNAME ?? options.env.USER;
@@ -710,7 +724,7 @@ export async function runSetup(options: SetupOptions): Promise<void> {
   const launchDomain = launchUid === undefined ? undefined : `gui/${String(launchUid)}`;
   const launchTarget = launchDomain === undefined ? undefined : `${launchDomain}/${LAUNCH_AGENT_LABEL}`;
   const windowsScript = platform === 'win32'
-    ? renderWindowsServiceScript({ dataDir, logDir, nodePath, runtime: serviceRuntime, servicePath, tokenPath })
+    ? renderWindowsServiceScript({ dataDir, logDir, nodeModulePath, nodePath, runtime: serviceRuntime, servicePath, tokenPath })
     : undefined;
   const windowsTask = platform === 'win32'
     ? renderWindowsScheduledTask({ scriptPath: windowsScriptPath, user: windowsUser! })
@@ -750,11 +764,12 @@ export async function runSetup(options: SetupOptions): Promise<void> {
       options.out(`[dry-run] write ${envPath} mode 600`);
       options.out('CODOR_TOKEN=<redacted generated-or-existing token>');
       options.out(`PATH=${servicePath}`);
+      if (nodeModulePath !== undefined) options.out(`NODE_PATH=${nodeModulePath}`);
       options.out('[dry-run] systemctl --user daemon-reload');
       options.out('[dry-run] systemctl --user enable --now codor.service');
     } else if (platform === 'darwin') {
       const launchAgent = renderLaunchAgent({
-        dataDir, logDir, nodePath, runtime: serviceRuntime, servicePath,
+        dataDir, logDir, nodeModulePath, nodePath, runtime: serviceRuntime, servicePath,
         token: '<redacted generated-or-existing token>',
       });
       options.out(`[dry-run] create ${logDir} mode 700`);
@@ -891,7 +906,8 @@ export async function runSetup(options: SetupOptions): Promise<void> {
       mkdirSync(userUnitDir, { recursive: true, mode: 0o700 });
       writeFileSync(userUnitPath, unitContent!, { encoding: 'utf8', mode: 0o600 });
       chmodSync(userUnitPath, 0o600);
-      writeFileSync(envPath, `CODOR_TOKEN=${token}\nPATH=${servicePath}\n`, { encoding: 'utf8', mode: 0o600 });
+      const nodePathEnvLine = nodeModulePath === undefined ? '' : `NODE_PATH=${nodeModulePath}\n`;
+      writeFileSync(envPath, `CODOR_TOKEN=${token}\nPATH=${servicePath}\n${nodePathEnvLine}`, { encoding: 'utf8', mode: 0o600 });
       chmodSync(envPath, 0o600);
       exec('systemctl', ['--user', 'daemon-reload']);
       exec('systemctl', ['--user', 'enable', '--now', 'codor.service']);
@@ -907,7 +923,7 @@ export async function runSetup(options: SetupOptions): Promise<void> {
       mkdirSync(logDir, { recursive: true, mode: 0o700 });
       chmodSync(logDir, 0o700);
       writeFileSync(launchAgentPath, renderLaunchAgent({
-        dataDir, logDir, nodePath, runtime: serviceRuntime, servicePath, token,
+        dataDir, logDir, nodeModulePath, nodePath, runtime: serviceRuntime, servicePath, token,
       }), { encoding: 'utf8', mode: 0o600 });
       chmodSync(launchAgentPath, 0o600);
       await bootstrapLaunchAgent({


### PR DESCRIPTION
## Problem

pnpm's `.bin` shim sets `NODE_PATH` to include the hidden hoist directory (`node_modules/.pnpm/node_modules`) before invoking Node -- that's what lets the CLI resolve modules like `bogon`'s undeclared `b4a` dependency (a separate upstream issue, not fixed here). The generated per-platform service bypasses the shim entirely and invokes Node directly, propagating only `PATH`. Module resolution then has no fallback, which is fatal specifically when normal ancestor-directory resolution cannot reach the hidden hoist dir -- the pnpm global-virtual-store layout, where the resolved module's realpath sits inside the store rather than under the project tree. There the service dies immediately with `Cannot find module 'b4a'`, while the CLI itself, launched through the shim, works fine. This is what installer step 4/5 surfaces as `Codor did not become ready at http://127.0.0.1:8137`. (The fix is a harmless no-op for other pnpm layouts, where module resolution already succeeds without it.)

## Fix

All three platform generators (Windows service script, launchd plist, systemd environment file) now emit `NODE_PATH` alongside `PATH`, derived the same way the entrypoint already is:

- **Probe the source, emit the destination.** `installDurableRuntime` may copy the invoking runtime's `node_modules` wholesale to a durable location (`~/.codor/runtime`) before the service ever runs, so the hoist directory is checked for existence at the *source* install root (which exists at render time) but the value emitted is rooted at the *destination* (`serviceLocation`) -- the same split `setup.ts` already makes for the entrypoint path at `setup.ts:667-668`.
- When no hoist directory is found (npm/yarn installs, or any layout without one), no `NODE_PATH` line is emitted at all -- a no-op for non-pnpm layouts.
- Escaping follows each generator's existing convention: PowerShell single-quote doubling, XML entity escaping, and the systemd env file's existing bare-value convention (matching how `PATH=` is already written there).

## Testing

- `packages/cli/src/setup-win32.spec.ts`: added a case creating a `.pnpm/node_modules` hoist dir under the fixture's checkout and asserting the rendered service script emits `$env:NODE_PATH`, plus negative assertions on the two existing cases (no hoist dir present -> no `NODE_PATH` line).
- `packages/cli/src/index.spec.ts`: updated the systemd dry-run inline snapshot to include the new `NODE_PATH=` line (this repo's own checkout is pnpm-linked, so the real hoist dir is detected); added positive assertions to the real systemd-write and macOS dry-run/install tests (both of which also run against this real checkout); added an explicit negative assertion to the existing npx-cache case, whose stubbed `installIo` reports no hoist dir at the source.
- **The case that actually proves the source/destination distinction**: every assertion above uses a durable source checkout, where `installSource.installRoot` and `serviceLocation` happen to be the same path -- so none of them alone would catch a source/destination swap in the derivation. Added a dedicated case (plain `it`, runs on every platform) sibling to the npx-cache test, with its own `installIo` stub reporting the source hoist dir present while an ephemeral runtime is mid-copy to `~/.codor/runtime`, asserting `NODE_PATH` lands on the durable copy and contains no trace of the ephemeral source path. Verified this case is load-bearing by temporarily inverting the probe/emit paths locally (probe the destination, emit the source) and confirming it fails against this exact committed test -- the destination doesn't exist yet for a fresh install, so no `NODE_PATH` is emitted at all -- then reverting and confirming it passes again.
- Gate run on Windows 11 (branched from unpatched `origin/main` at `bc47942`): `pnpm install --frozen-lockfile` and `pnpm -r build` both succeed. `cd packages/cli && pnpm exec vitest run` (direct invocation -- `pnpm test` cannot spawn Vitest on Windows before the separate Windows-portability PR lands) shows **177 passed, 18 skipped, 5 failed** -- the same 5 pre-existing baseline failures tracked separately, no others.

### What could not be executed here

The remaining `index.spec.ts` assertions this PR touches (the real systemd-write test and the macOS dry-run/install test) are inside `posixHostIt`-guarded tests, skipped on Windows because they assert exact POSIX permission-bit values (`statSync(...).mode`) that NTFS does not track -- unrelated to this change. To verify the derivation logic itself on Windows without that unrelated skip, I exercised the same two code paths (real systemd write, real darwin dry-run render) against throwaway scratch copies of those tests using plain `it`, confirmed each behaves as expected, then discarded the scratch files -- they are not part of this PR, and those two specific assertions were not executed by CI in this session. A Linux or macOS run is needed to confirm them directly. (The ephemeral-runtime case above, and the win32 case, are *not* in this category -- both run as plain tests and were verified directly, no scratch copy involved.)

**No real end-to-end service run was performed.** I did not remove a source runtime, let a service start against the durable copy, and confirm it actually resolves `b4a` in practice. Everything above verifies the derivation logic (the right path is computed and emitted); it does not verify the running service. That end-to-end check is a manual one a reviewer would need to perform.

The launchd and systemd paths are otherwise unverified on macOS/Linux beyond the above. `NODE_PATH` is consulted by CommonJS `require()` resolution only, not ESM `import` -- this repairs the present CommonJS-based failure and any layout that fails the same way, not a general linker-independent guarantee.

## Notes for review

- `serviceLocation`'s durability currently depends on `isEphemeralRuntime` correctly classifying the invoking runtime (a separate, already-open PR extends that classifier to pnpm's `dlx` cache). Neither fix subsumes the other: that PR decides whether `serviceLocation` resolves to `~/.codor/runtime` or a transient cache; this PR is what makes `NODE_PATH` follow `serviceLocation` either way.
- This is a process-lifecycle change to the generated service environment, so I've opened it as a draft pending review of the two touched assumptions below.
- This branch's single commit is the result of a squash (three review-round commits combined, with corrected wording) followed by a force-push; the resulting tree is unchanged from before the squash.

Touches `windows-setup-installs-private-task-service` (`setup.ts:556`) and `setup-preserves-private-platform-service` (`setup.ts:636`), both `active`. No `.harn/assumptions/` files were edited directly.