### PR TITLE
fix(deps): add allowBuilds for pnpm 10.26+/11 alongside onlyBuiltDependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,13 @@ packages:
   - website
   - relay
 # harn:end workspace-gates-cover-all-buildable-projects
+
+# pnpm >= 10.26 reads allowBuilds instead of the package.json "pnpm.onlyBuiltDependencies"
+# field below, which pnpm 11 ignores outright (see docs/issues/codor-install-issues.md, Issue E).
+# Kept in addition to that field, not in place of it: the packageManager pin stays at
+# pnpm@10.9.0, which predates allowBuilds and only reads the package.json field.
+allowBuilds:
+  better-sqlite3: true
+  esbuild: true
+  sodium-native: true
+  udx-native: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,10 +7,10 @@ packages:
   - relay
 # harn:end workspace-gates-cover-all-buildable-projects
 
-# pnpm >= 10.26 reads allowBuilds instead of the package.json "pnpm.onlyBuiltDependencies"
-# field below, which pnpm 11 ignores outright (see docs/issues/codor-install-issues.md, Issue E).
-# Kept in addition to that field, not in place of it: the packageManager pin stays at
-# pnpm@10.9.0, which predates allowBuilds and only reads the package.json field.
+# pnpm >= 10.26 reads build-script approvals from this map instead of the "pnpm.onlyBuiltDependencies"
+# field in package.json, which pnpm 11 ignores outright. Kept in addition to that field, not in
+# place of it: package.json's "packageManager" pin stays at pnpm@10.9.0, which predates
+# allowBuilds (added in 10.26.0) and only reads the package.json field.
 allowBuilds:
   better-sqlite3: true
   esbuild: true


### PR DESCRIPTION
## Problem

pnpm >= 10.26 (and pnpm 11) read build-script approvals from a
`pnpm-workspace.yaml` `allowBuilds` map. They no longer honour the
`pnpm.onlyBuiltDependencies` field this repo currently declares in
`package.json`:

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were
       ignored: "pnpm.onlyBuiltDependencies". See https://pnpm.io/settings for the new home
       of each setting.
```

A contributor whose toolchain resolves to pnpm >= 10.26 — including anyone who overrides or
bypasses the `packageManager` pin below — gets no build approval for `better-sqlite3`,
`esbuild`, `sodium-native`, or `udx-native`. `better-sqlite3` ships no native binding without
its install script, so the workspace builds but the service cannot start.

## Fix

Add an `allowBuilds` map to `pnpm-workspace.yaml` with the same four packages already listed
in `package.json`'s `pnpm.onlyBuiltDependencies`, additively:

- `packageManager` stays pinned at `pnpm@10.9.0` — moving it is a separate, maintainer-owned
  decision (bumping the pin, running pnpm's v10→v11 migration codemod, and dropping the
  `package.json` field would drag the lockfile with it; out of scope here).
- The existing `package.json` `pnpm` field is untouched.
- `pnpm@10.9.0` predates `allowBuilds` (added in 10.26.0) and simply ignores the unrecognized
  key; pnpm >= 10.26 and 11 read it and ignore the now-unread `package.json` field. Both
  toolchains end up approving the same four packages.

## Testing

Environment: Windows 11, global pnpm 11.17.0, this repo's `packageManager` pin resolving to a
reported `10.9.0`.

```
pnpm install --frozen-lockfile   # clean, no "Ignored build scripts" warning; Scope: all 18 workspace projects
pnpm -r build                    # succeeds; Scope: 17 of 18 workspace projects (one package defines no build script)
cd packages/cli
pnpm exec vitest run             # `pnpm test` can't spawn Vitest on Windows yet (separate,
                                  # already-open portability PR); direct invocation used instead
```

Vitest: 4 files failed / 12 passed / 2 skipped, 175 passed / 5 failed / 18 skipped — the same
five pre-existing baseline failures tracked separately, none introduced by this change.

`pnpm -r test`, the gate CONTRIBUTING.md asks for, still aborts with
`ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL` inside `packages/adapters/antigravity` before it ever reaches
`packages/cli` — a pre-existing, unrelated failure tracked separately (an `interrupted` vs.
`failed` status assertion). This PR does not fix that and does not make `pnpm -r test` pass; it's
reported here so the gate's current state is stated rather than implied.

**Honest limitations:**

- This environment's `node_modules` already had `better-sqlite3`'s native binding built from a
  prior install, so this change was not verified by observing a *fresh* install go from
  "ignored" to "approved" from a clean tree — only that the current install stays clean with no
  ignored-builds warning and no regression. A reviewer on a from-scratch clone is better
  positioned to confirm that transition.
- I also observed that even the pinned/reported `10.9.0` invocation here already prints the
  "pnpm field is no longer read" warning for `pnpm.onlyBuiltDependencies`, earlier than pnpm's
  own docs date that behaviour ("since v11"). I could not fully attribute that to a specific
  mechanism (e.g. the outer globally-installed v11 binary's own pre-flight before it delegates
  to the pinned version, vs. a genuine behavior change in 10.9.0 itself). It doesn't change the
  fix: `allowBuilds` in `pnpm-workspace.yaml` covers this case regardless of which binary ends
  up doing the real work.

No Harn assumption block is touched — this changes build-script approval configuration only.