### PR TITLE
Fix Codex app-server launch through Windows command shims

### DIFF
--- a/.harn/assumptions/codex-app-server-resolves-windows-command-shims.yaml
+++ b/.harn/assumptions/codex-app-server-resolves-windows-command-shims.yaml
@@ -1,0 +1,16 @@
+id: codex-app-server-resolves-windows-command-shims
+hash: a-00e8c4af7df6
+title: The Codex app-server launcher resolves Windows command shims
+state: active
+statement: The persistent Codex app-server launcher must use cross-spawn for the
+  exact command and app-server argument while preserving cwd, inherited member
+  environment, piped stdio, detached false, spawn-or-error settlement, returned
+  child ownership, and all later lifecycle behavior, because Windows
+  installations commonly expose Codex through a .cmd shim that native Node spawn
+  does not consistently resolve.
+depends_on:
+  - codex-app-server-is-the-member-runtime
+  - codex-app-server-contract-is-pinned-to-0-144-5
+  - adapter-children-inherit-session-env
+  - adapter-process-lifecycle-supervised
+created_by: issue8-windows-codex-app-server-spawn

--- a/.harn/plans/issue8-windows-codex-app-server-spawn.yaml
+++ b/.harn/plans/issue8-windows-codex-app-server-spawn.yaml
@@ -1,0 +1,70 @@
+id: issue8-windows-codex-app-server-spawn
+title: Resolve Windows command shims for the Codex app-server launcher
+notes: "Issue #8 is implemented only at the persistent Codex app-server
+  launcher. The native child_process spawn provider is replaced with cross-spawn
+  while the command, app-server argv, cwd, environment, piped stdio, detached
+  setting, spawn/error settlement, returned child type, JSON-RPC transport,
+  ownership, and lifecycle remain unchanged. This plan does not use shell:true
+  and does not touch interactive attach, custody, other adapters, synchronous
+  discovery, or a broader launch abstraction."
+assumptions:
+  create:
+    - id: codex-app-server-resolves-windows-command-shims
+      title: The Codex app-server launcher resolves Windows command shims
+      statement: The persistent Codex app-server launcher must use cross-spawn for the
+        exact command and app-server argument while preserving cwd, inherited
+        member environment, piped stdio, detached false, spawn-or-error
+        settlement, returned child ownership, and all later lifecycle behavior,
+        because Windows installations commonly expose Codex through a .cmd shim
+        that native Node spawn does not consistently resolve.
+      reason: "Issue #8 reports spawn codex ENOENT on Windows even though the
+        installed codex.cmd is available on PATH."
+      depends_on:
+        - codex-app-server-is-the-member-runtime
+        - codex-app-server-contract-is-pinned-to-0-144-5
+        - adapter-children-inherit-session-env
+        - adapter-process-lifecycle-supervised
+  reviewed:
+    - id: codex-app-server-is-the-member-runtime
+      outcome: unchanged
+      reason: Persistent-child ownership, reuse, replacement, interruption, and member
+        environment semantics remain unchanged.
+    - id: codex-app-server-contract-is-pinned-to-0-144-5
+      outcome: unchanged
+      reason: Only the spawn provider changes; app-server argv, JSONL JSON-RPC,
+        protocol version, transport, and fake-server contract remain unchanged.
+    - id: adapter-children-inherit-session-env
+      outcome: unchanged
+      reason: The launcher continues to receive the exact environment already merged
+        by the Codex adapter.
+    - id: adapter-process-lifecycle-supervised
+      outcome: unchanged
+      reason: Spawn/error observation, retained-child shutdown, active-turn failure,
+        and interruption behavior remain unchanged.
+files:
+  - packages/adapters/codex/package.json
+  - packages/adapters/codex/src/app-server-transport.ts
+  - packages/adapters/codex/src/app-server-transport.spec.ts
+  - packages/adapters/codex/src/app-server-transport.windows.spec.ts
+  - pnpm-lock.yaml
+anchors:
+  codex-app-server-resolves-windows-command-shims:
+    codex-app-server-portable-spawn-provider:
+      action: change
+      reason: Anchor the cross-spawn call with the exact existing command, argv, and
+        options.
+    codex-app-server-portable-spawn-regression:
+      action: change
+      reason: Anchor focused mocked-provider coverage for exact launch inputs and
+        spawn/error settlement.
+    codex-app-server-windows-shim-regression:
+      action: change
+      reason: Anchor a Windows-only real codex.cmd resolution and piped lifecycle
+        regression.
+  codex-app-server-contract-is-pinned-to-0-144-5:
+    codex-app-server-transport:
+      action: change
+      reason: Add the nested portable-launcher anchor and swap only its provider
+        inside the existing transport contract.
+applied:
+  applied_at: 2026-07-27T08:43:17.781Z

--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -17,6 +17,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@codor/protocol": "workspace:*"
+    "@codor/protocol": "workspace:*",
+    "cross-spawn": "^7.0.6"
+  },
+  "devDependencies": {
+    "@types/cross-spawn": "^6.0.6"
   }
 }

--- a/packages/adapters/codex/src/app-server-transport.spec.ts
+++ b/packages/adapters/codex/src/app-server-transport.spec.ts
@@ -1,0 +1,66 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+
+import spawn from 'cross-spawn';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { spawnCodexAppServer } from './app-server-transport.js';
+
+vi.mock('cross-spawn', () => ({ default: vi.fn() }));
+
+function fakeChild(): ChildProcessWithoutNullStreams {
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: PassThrough;
+    stdout: PassThrough;
+    stderr: PassThrough;
+  };
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  return child as unknown as ChildProcessWithoutNullStreams;
+}
+
+// harn:assume codex-app-server-resolves-windows-command-shims ref=codex-app-server-portable-spawn-regression
+describe('portable Codex app-server launcher', () => {
+  beforeEach(() => {
+    vi.mocked(spawn).mockReset();
+  });
+
+  it('passes the exact command, argv, and retained-child options', async () => {
+    const child = fakeChild();
+    vi.mocked(spawn).mockReturnValue(child);
+    const env = { PATH: '/tools', CODOR_MEMBER_ID: 'member-codex' };
+
+    const launched = spawnCodexAppServer({
+      command: '/tools/codex',
+      cwd: '/work',
+      env,
+    });
+
+    expect(spawn).toHaveBeenCalledWith('/tools/codex', ['app-server'], {
+      cwd: '/work',
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      detached: false,
+    });
+    child.emit('spawn');
+    await expect(launched).resolves.toBe(child);
+    expect(child.listenerCount('error')).toBe(0);
+  });
+
+  it('rejects startup errors without waiting for a spawn event', async () => {
+    const child = fakeChild();
+    vi.mocked(spawn).mockReturnValue(child);
+    const launched = spawnCodexAppServer({
+      command: 'codex',
+      cwd: '/work',
+      env: { PATH: '/tools' },
+    });
+
+    child.emit('error', new Error('spawn codex ENOENT'));
+    await expect(launched).rejects.toThrow('spawn codex ENOENT');
+    expect(child.listenerCount('spawn')).toBe(0);
+  });
+});
+// harn:end codex-app-server-resolves-windows-command-shims

--- a/packages/adapters/codex/src/app-server-transport.ts
+++ b/packages/adapters/codex/src/app-server-transport.ts
@@ -1,8 +1,6 @@
-import {
-  type ChildProcessWithoutNullStreams,
-  spawn,
-} from 'node:child_process';
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
 import { createInterface, type Interface as ReadlineInterface } from 'node:readline';
+import spawn from 'cross-spawn';
 
 const REQUEST_TIMEOUT_MS = 30_000;
 const STDERR_LIMIT = 8 * 1024;
@@ -48,6 +46,7 @@ export function spawnCodexAppServer(
   context: CodexAppServerSpawnContext,
 ): Promise<ChildProcessWithoutNullStreams> {
   return new Promise((resolve, reject) => {
+    // harn:assume codex-app-server-resolves-windows-command-shims ref=codex-app-server-portable-spawn-provider
     const child = spawn(context.command, ['app-server'], {
       cwd: context.cwd,
       env: context.env,
@@ -55,7 +54,8 @@ export function spawnCodexAppServer(
       // stdin EOF on daemon exit is the final ownership boundary. Unlike the
       // old per-turn driver, interruption is an RPC and needs no process group.
       detached: false,
-    });
+    }) as ChildProcessWithoutNullStreams;
+    // harn:end codex-app-server-resolves-windows-command-shims
     const onError = (error: Error) => {
       child.off('spawn', onSpawn);
       reject(error);

--- a/packages/adapters/codex/src/app-server-transport.windows.spec.ts
+++ b/packages/adapters/codex/src/app-server-transport.windows.spec.ts
@@ -1,0 +1,51 @@
+import { once } from 'node:events';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { spawnCodexAppServer } from './app-server-transport.js';
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+// harn:assume codex-app-server-resolves-windows-command-shims ref=codex-app-server-windows-shim-regression
+describe.skipIf(process.platform !== 'win32')('Codex app-server Windows command shim', () => {
+  it('resolves codex.cmd from PATH and preserves piped app-server lifecycle', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'codor-codex-shim-'));
+    dirs.push(dir);
+    const node = process.execPath.replaceAll('"', '""');
+    writeFileSync(
+      join(dir, 'codex.cmd'),
+      `@"${node}" -e "process.stdin.resume();process.stdin.on('end',function(){process.stdout.write(process.argv[1]||'')})" %*\r\n`,
+    );
+
+    const child = await spawnCodexAppServer({
+      command: 'codex',
+      cwd: dir,
+      env: {
+        ...process.env,
+        PATH: `${dir}${delimiter}${process.env.PATH ?? ''}`,
+      },
+    });
+    let stdout = '';
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    const closed = once(child, 'close');
+    child.stdin.end();
+    const [code, signal] = await closed;
+
+    expect({ code, signal, stdout }).toEqual({
+      code: 0,
+      signal: null,
+      stdout: 'app-server',
+    });
+  });
+});
+// harn:end codex-app-server-resolves-windows-command-shims

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,13 @@ importers:
       '@codor/protocol':
         specifier: workspace:*
         version: link:../../protocol
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
+    devDependencies:
+      '@types/cross-spawn':
+        specifier: ^6.0.6
+        version: 6.0.6
 
   packages/adapters/copilot:
     dependencies:


### PR DESCRIPTION
## Summary

Refs #8.

- replace only the native spawn provider in spawnCodexAppServer with cross-spawn
- preserve the exact codex command, app-server argv, cwd, environment, piped stdio, detached false, spawn/error settlement, child type, and lifecycle
- add cross-spawn and its types directly to @codor/adapter-codex
- add focused provider tests plus a Windows-only real codex.cmd PATH regression

This PR does not use shell:true or windowsHide. It does not touch interactive attach, custody, synchronous discovery, another adapter, protocol behavior, or a broader launch abstraction.

## Harn

Plan: issue8-windows-codex-app-server-spawn

The plan was checked and locked on clean merged main at 84417642b7e02565b86093ec48aa11f5e48b241a with dirty_at_lock:false before implementation. The single implementation commit applies that plan and creates codex-app-server-resolves-windows-command-shims.

## Validation

- pnpm install --frozen-lockfile: passed
- focused transport tests: 2 passed; Windows real-shim test platform-skipped on this Linux runner
- @codor/adapter-codex build: passed
- @codor/adapter-codex test: 8 files passed, 2 skipped; 79 tests passed, 4 skipped
- pnpm -r build: passed in 26.94s, including website verification and web-next
- pnpm -r test: reproduced only the accepted pre-existing ACP fixed-50ms cancellation startup timeout
- isolated ACP cancellation regression: 1/1 passed in 63ms
- isolated ACP package: 14/14 passed
- Harn locked, staged, applied, and final staged checks: passed

The real codex.cmd resolution test will execute only on a native Windows runner. No live Codex process or model request was used.