### PR TITLE
docs: disclose npm 12 install-script approval and runtime recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,15 @@ expiry. It never sends channel data through a Codor-hosted service.
 
 <!-- harn:assume pnpm-install-docs-disclose-build-approval-boundaries ref=readme-pnpm-install-disclosure -->
 > [!NOTE]
-> On pnpm, install into a project rather than running `pnpm dlx @richhardry/codor install`. A tested
-> `pnpm dlx` install did not pick up the workspace `packageExtensions` and native build-approval
-> settings this install needs—see [Self-host: Prerequisites](docs/SELF-HOST.md#prerequisites) for
-> the settings.
+> Codor's native `better-sqlite3` binding needs its dependency install script to run, and current
+> package managers block dependency scripts by default. On pnpm, install into a project rather than
+> running `pnpm dlx @richhardry/codor install`: a tested `pnpm dlx` install did not pick up the
+> workspace `packageExtensions` and native build-approval settings this install needs. On npm 12,
+> `npx` applies the same boundary—pass
+> `--allow-scripts=better-sqlite3,sodium-native,udx-native` on the install command, or persist it
+> with `npm config set allow-scripts=better-sqlite3,sodium-native,udx-native --location=user`. See
+> [Self-host: Prerequisites](docs/SELF-HOST.md#prerequisites) for the settings and for recovery if a
+> previous install already skipped the scripts.
 <!-- harn:end pnpm-install-docs-disclose-build-approval-boundaries -->
 
 Preview without changing the host:

--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ expiry. It never sends channel data through a Codor-hosted service.
 > package managers block dependency scripts by default. On pnpm, install into a project rather than
 > running `pnpm dlx @richhardry/codor install`: a tested `pnpm dlx` install did not pick up the
 > workspace `packageExtensions` and native build-approval settings this install needs. On npm 12,
-> `npx` applies the same boundary—pass
-> `--allow-scripts=better-sqlite3,sodium-native,udx-native` on the install command, or persist it
-> with `npm config set allow-scripts=better-sqlite3,sodium-native,udx-native --location=user`. See
+> `npx` applies the same boundary—run
+> `npx --allow-scripts=better-sqlite3,sodium-native,udx-native @richhardry/codor install`, keeping
+> the option before the package because `npx` forwards trailing options to Codor instead of npm.
+> Persist the approval instead with
+> `npm config set allow-scripts=better-sqlite3,sodium-native,udx-native --location=user`. See
 > [Self-host: Prerequisites](docs/SELF-HOST.md#prerequisites) for the settings and for recovery if a
 > previous install already skipped the scripts.
 <!-- harn:end pnpm-install-docs-disclose-build-approval-boundaries -->

--- a/docs/SELF-HOST.md
+++ b/docs/SELF-HOST.md
@@ -15,14 +15,25 @@ machine. No hosted Codor component is required.
 - Optional: Tailscale for private HTTPS access from phones and other machines.
 
 <!-- harn:assume pnpm-install-docs-disclose-build-approval-boundaries ref=selfhost-pnpm-build-approval-disclosure -->
-On pnpm 10.1–10.25, `better-sqlite3`'s native build script needs approval via
+Codor's `better-sqlite3` native module has no binding until its dependency install script runs, and
+current package managers block dependency scripts by default. On pnpm 10.1–10.25, approve it via
 `onlyBuiltDependencies: [better-sqlite3]` in `pnpm-workspace.yaml` or the `package.json` `pnpm`
 field. On pnpm 10.26 and newer (including pnpm 11), that setting is `allowBuilds: { better-sqlite3:
-true }` in `pnpm-workspace.yaml`—`pnpm approve-builds` writes it interactively. Without approval,
-`pnpm install` reports `Ignored build scripts: better-sqlite3` and the service fails to start with
-no native binding. See [pnpm's settings reference](https://pnpm.io/settings) for the current option
-names.
+true }` in `pnpm-workspace.yaml`—`pnpm approve-builds` writes it interactively. On npm 12, `npx`
+applies the same boundary: pass
+`--allow-scripts=better-sqlite3,sodium-native,udx-native` on the install command, or persist it with
+`npm config set allow-scripts=better-sqlite3,sodium-native,udx-native --location=user`. Without
+approval, `pnpm install` reports `Ignored build scripts: better-sqlite3` and npm skips the scripts
+with only a warning; either way the service fails to start with no native binding. See
+[pnpm's settings reference](https://pnpm.io/settings) for the current option names.
 <!-- harn:end pnpm-install-docs-disclose-build-approval-boundaries -->
+
+If a Codor install already skipped those scripts and step 4 later failed with a readiness timeout,
+the durable runtime still holds the broken copy: a rerun at the same version reuses
+`<data-dir>/runtime` (default `~/.codor/runtime`), so the missing binding persists. Rebuild the
+package manager's transient cache entry with scripts allowed—remove the stale npx `_npx/` or pnpm
+`dlx/` cache entry so the next install does not reuse it—then either choose **Reinstall** during
+`codor install` or remove `<data-dir>/runtime` before rerunning.
 
 Never expose port 8137 directly to the public internet. The browser token is a bearer credential;
 use loopback plus Tailscale Serve, another authenticated private tunnel, or a hardened reverse

--- a/docs/SELF-HOST.md
+++ b/docs/SELF-HOST.md
@@ -20,11 +20,13 @@ current package managers block dependency scripts by default. On pnpm 10.1–10.
 `onlyBuiltDependencies: [better-sqlite3]` in `pnpm-workspace.yaml` or the `package.json` `pnpm`
 field. On pnpm 10.26 and newer (including pnpm 11), that setting is `allowBuilds: { better-sqlite3:
 true }` in `pnpm-workspace.yaml`—`pnpm approve-builds` writes it interactively. On npm 12, `npx`
-applies the same boundary: pass
-`--allow-scripts=better-sqlite3,sodium-native,udx-native` on the install command, or persist it with
+applies the same boundary: run
+`npx --allow-scripts=better-sqlite3,sodium-native,udx-native @richhardry/codor install`, keeping
+the option before the package because `npx` forwards trailing options to Codor instead of npm. Or
+persist the approval with
 `npm config set allow-scripts=better-sqlite3,sodium-native,udx-native --location=user`. Without
-approval, `pnpm install` reports `Ignored build scripts: better-sqlite3` and npm skips the scripts
-with only a warning; either way the service fails to start with no native binding. See
+approval, `pnpm install` reports `Ignored build scripts: better-sqlite3` and npm's `npx` skips the
+scripts silently; either way the service fails to start with no native binding. See
 [pnpm's settings reference](https://pnpm.io/settings) for the current option names.
 <!-- harn:end pnpm-install-docs-disclose-build-approval-boundaries -->
 


### PR DESCRIPTION
## Problem

`README.md` tells users to run `npx @richhardry/codor install`, and the pnpm note plus
`docs/SELF-HOST.md` explain pnpm's build-approval boundary. Two gaps remain:

1. npm 12 blocks dependency install scripts by default and, for `npx`, skips them silently unless the
   package is allowed. A user on npm 12 gets a runtime with no `better-sqlite3` binding, and step 4
   then fails with a readiness timeout that names the probe, not the cause.
2. No document, for either package manager, says how to recover. After approval is fixed, a
   same-version rerun reuses the broken durable runtime at `<data-dir>/runtime`, so the failure
   persists.

## Intended result

`README.md` and `docs/SELF-HOST.md` name the npm 12 requirement beside the existing pnpm one and add
one package-manager-neutral recovery paragraph.

Docs only. No code, configuration, or existing link target changed. No new external link added.

## Changes

- README install note and Self-host prerequisites now say: on npm 12 run
  `npx --allow-scripts=better-sqlite3,sodium-native,udx-native @richhardry/codor install` (the
  option must precede the package; a trailing option is forwarded to Codor, not npm), or persist it
  with `npm config set allow-scripts=better-sqlite3,sodium-native,udx-native --location=user`.
  Checked against npm v12's `npm-install-scripts` and `npm-exec` docs, which state dependency install
  scripts are blocked by default, that `--allow-scripts` is the opt-in for `-g` and `npx`, and that
  `npx` requires options before positional arguments. Also observed on npm 12.0.2:
  `npx --allow-scripts=vitest vitest --version` has npm consume the flag, while
  `npx vitest --allow-scripts=vitest --version` logs `run vitest --allow-scripts=vitest --version`.
- Self-host prerequisites gain one recovery paragraph: rebuild the transient cache entry (`_npx/`
  or `dlx/`) with scripts allowed, then choose **Reinstall** during `codor install` or remove
  `<data-dir>/runtime` before rerunning, because a same-version rerun reuses it.

## Test commands and results

Docs-only, so the relevant checks are the consumers of these two files:

```sh
pnpm install --frozen-lockfile
pnpm -r build
pnpm --filter @codor/website build
node scripts/release-audit.mjs
```

- `pnpm install --frozen-lockfile`: passed via the pinned pnpm 10.9.0; `better-sqlite3` built.
- `pnpm -r build`: passed at the base docs commit (`dcdb07e`), including `@codor/website` and
  `verify-site.mjs` ("website verification passed: appearance, links, user unit, and 7 brand
  assets").
- The review commit (`eb82bc5`) edits only these two files, so it was re-checked through their two
  build/test consumers: `pnpm --filter @codor/website build` and `node scripts/release-audit.mjs`
  both passed.

Run on Windows 11 / Node 26.8.1 / pnpm 10.9.0.

## Not tested

- `pnpm -r test` does not complete on this Windows host: it aborts in `packages/adapters/acp`
  (`EPERM: operation not permitted, symlink ...`), so the recursive runner never reaches
  `packages/cli`. Upstream CI runs this gate on `ubuntu-24.04`.
- The recovery steps were not replayed end to end (no npm 12 host was set up to rebuild the cache and
  confirm the binding loads); they are documented from the diagnosis in #21. The package-manager
  observation is Windows-only there; the docs text is package-manager-generic.

## Harn

Touches `pnpm-install-docs-disclose-build-approval-boundaries` (README ref
`readme-pnpm-install-disclosure`, Self-host ref `selfhost-pnpm-build-approval-disclosure`). The
assumption stays true; this widens the disclosure to npm 12 and adds recovery guidance. Per
`CONTRIBUTING.md`, `.harn/assumptions/` is not edited here; a maintainer can extend and re-lock the
assumption.

Closes #21
