### PR TITLE
fix(cli): verify better-sqlite3 loads before the runtime swap

### DIFF
--- a/packages/cli/src/index.spec.ts
+++ b/packages/cli/src/index.spec.ts
@@ -839,6 +839,29 @@ describe('@codor/cli', () => {
       timeout.mockRestore();
     }
   });
+
+  // harn:assume setup-readiness-wait-is-wall-clock-bounded ref=readiness-log-path-regression
+  it('names the service log path in the readiness timeout when one is available', async () => {
+    const logPath = join(dir, '.codor', 'logs', 'codor.err.log');
+    let elapsedMs = 0;
+    const failure = await waitForCodor(
+      'http://127.0.0.1:65535',
+      async () => {
+        elapsedMs += 500;
+        return false;
+      },
+      async () => undefined,
+      () => elapsedMs,
+      1_000,
+      logPath,
+    ).then(
+      () => undefined,
+      (error: unknown) => error instanceof Error ? error.message : String(error),
+    );
+    if (failure === undefined) throw new Error('expected readiness to time out');
+    expect(failure).toContain(`service log at ${logPath}`);
+    expect(failure).not.toContain('user-service logs');
+  });
   // harn:end setup-readiness-wait-is-wall-clock-bounded
 
   // harn:assume platform-services-propagate-destination-pnpm-node-path ref=node-path-systemd-regression

--- a/packages/cli/src/runtime-install.spec.ts
+++ b/packages/cli/src/runtime-install.spec.ts
@@ -5,12 +5,14 @@ import { join, resolve, sep } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
+  defaultInstallIo,
   detectInstalledRuntime,
   finalizeDurableRuntimeInstall,
   installDurableRuntime,
   isEphemeralRuntime,
   rollbackDurableRuntimeInstall,
   type InstallIo,
+  type NativeProbeResult,
 } from './runtime-install.js';
 import { type RuntimePaths } from './runtime-paths.js';
 
@@ -73,7 +75,12 @@ const WRAPPER_PKG = (loc: string): string => join(loc, 'node_modules', '@richhar
 const STAGED_CLI = (loc: string): string => join(loc, 'node_modules', '@richhardry', 'codor', 'node_modules', '@codor', 'cli');
 
 /** A tiny virtual filesystem so the staged copy + atomic swap is testable. */
-function fakeIo(options: { existing?: string; failCopy?: boolean; incompleteCopy?: boolean } = {}): {
+function fakeIo(options: {
+  existing?: string;
+  failCopy?: boolean;
+  incompleteCopy?: boolean;
+  nativeProbe?: (cliRoot: string, nodePath: string) => NativeProbeResult;
+} = {}): {
   io: InstallIo; present: Set<string>; copies: Array<[string, string]>; moves: Array<[string, string]>; removed: string[];
 } {
   const copies: Array<[string, string]> = [];
@@ -115,6 +122,7 @@ function fakeIo(options: { existing?: string; failCopy?: boolean; incompleteCopy
       for (const existing of [...present]) if (existing === path || existing.startsWith(`${path}/`)) present.delete(existing);
     },
     readVersion: (path) => versions.get(path),
+    ...(options.nativeProbe === undefined ? {} : { probeNative: options.nativeProbe }),
   };
   return { io, present, copies, moves, removed };
 }
@@ -262,6 +270,171 @@ describe('installDurableRuntime', () => {
     expect(removed).toContain(`${LOCATION}.staging`);
     expect(present.has(LOCATION)).toBe(true);
     expect(moves).toEqual([]);
+  });
+});
+
+// harn:assume setup-installs-durable-per-user-runtime-atomically ref=durable-runtime-native-probe-regression
+describe('installDurableRuntime native-module staging validation', () => {
+  it('discards a staged runtime whose SQLite binding cannot load, naming the module and Node ABI', () => {
+    const probes: Array<{ cliRoot: string; nodePath: string }> = [];
+    const { io, present, removed, moves } = fakeIo({
+      existing: '0.9.0',
+      nativeProbe: (cliRoot, nodePath) => {
+        probes.push({ cliRoot, nodePath });
+        return { ok: false, detail: 'better-sqlite3 could not open a database under Node ABI 137 (win32-x64): Could not locate the bindings file' };
+      },
+    });
+    let failure: Error | undefined;
+    try {
+      installDurableRuntime({
+        runtime: ephemeral,
+        dataDir: DATA,
+        version: '0.10.0',
+        intent: 'update',
+        nodePath: '/service/node',
+        io,
+      });
+    } catch (error) {
+      failure = error as Error;
+    }
+    if (failure === undefined) throw new Error('expected the staged native check to fail');
+    expect(failure.message).toContain('better-sqlite3');
+    expect(failure.message).toContain('Node ABI 137');
+    expect(probes).toEqual([{ cliRoot: STAGED_CLI(`${LOCATION}.staging`), nodePath: '/service/node' }]);
+    // The incomplete staging is discarded; the existing install is untouched.
+    expect(removed).toContain(`${LOCATION}.staging`);
+    expect(present.has(LOCATION)).toBe(true);
+    expect(moves).toEqual([]);
+  });
+
+  it('swaps a staged runtime after its native probe passes', () => {
+    const probes: Array<{ cliRoot: string; nodePath: string }> = [];
+    const { io, moves } = fakeIo({
+      nativeProbe: (cliRoot, nodePath) => {
+        probes.push({ cliRoot, nodePath });
+        return { ok: true };
+      },
+    });
+    const result = installDurableRuntime({
+      runtime: ephemeral,
+      dataDir: DATA,
+      version: '0.10.0',
+      nodePath: '/service/node',
+      io,
+    });
+    expect(result.action).toBe('installed');
+    expect(probes).toEqual([{ cliRoot: STAGED_CLI(`${LOCATION}.staging`), nodePath: '/service/node' }]);
+    expect(moves).toContainEqual([`${LOCATION}.staging`, LOCATION]);
+  });
+
+  it('does not reuse a same-version runtime whose native modules cannot load', () => {
+    const { io, copies } = fakeIo({
+      existing: '0.10.0',
+      nativeProbe: (cliRoot) => (cliRoot.includes('.staging')
+        ? { ok: true }
+        : { ok: false, detail: 'better-sqlite3 could not open a database' }),
+    });
+    const result = installDurableRuntime({
+      runtime: ephemeral,
+      dataDir: DATA,
+      version: '0.10.0',
+      nodePath: '/service/node',
+      io,
+    });
+    expect(result.action).toBe('updated');
+    expect(copies).toHaveLength(1);
+  });
+
+  it('reuses a same-version runtime that passes its native probe', () => {
+    const { io, copies } = fakeIo({ existing: '0.10.0', nativeProbe: () => ({ ok: true }) });
+    const result = installDurableRuntime({
+      runtime: ephemeral,
+      dataDir: DATA,
+      version: '0.10.0',
+      nodePath: '/service/node',
+      io,
+    });
+    expect(result.action).toBe('reused');
+    expect(copies).toEqual([]);
+  });
+});
+// harn:end setup-installs-durable-per-user-runtime-atomically
+
+describe('default native probe', () => {
+  it('names better-sqlite3 and the Node ABI when the staged tree lacks the binding', () => {
+    const cliRoot = mkdtempSync(join(tmpdir(), 'codor-native-probe-'));
+    try {
+      const outcome = defaultInstallIo.probeNative!(cliRoot, process.execPath);
+      expect(outcome.ok).toBe(false);
+      expect(outcome.detail).toContain('better-sqlite3');
+      expect(outcome.detail).toContain(`Node ABI ${process.versions.modules ?? ''}`);
+    } finally {
+      rmSync(cliRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores an inherited NODE_PATH that could resolve the dependency', () => {
+    const root = mkdtempSync(join(tmpdir(), 'codor-native-probe-nodepath-'));
+    try {
+      // A hoist directory, as pnpm exposes through NODE_PATH and the service
+      // writes into its own environment, that could satisfy both lookups.
+      const hoist = join(root, 'hoist');
+      mkdirSync(join(hoist, '@codor', 'switchboard', 'dist'), { recursive: true });
+      writeFileSync(join(hoist, '@codor', 'switchboard', 'package.json'), JSON.stringify({
+        name: '@codor/switchboard', type: 'module', exports: { '.': './dist/index.js' },
+      }));
+      writeFileSync(join(hoist, '@codor', 'switchboard', 'dist', 'index.js'), '');
+      const database = join(hoist, 'better-sqlite3');
+      mkdirSync(database, { recursive: true });
+      writeFileSync(join(database, 'package.json'), JSON.stringify({ name: 'better-sqlite3', main: 'index.js' }));
+      writeFileSync(join(database, 'index.js'), 'module.exports = function Database() { return { close() {} }; };\n');
+      // The staged tree is empty; only the inherited NODE_PATH could resolve the
+      // dependency, and the probe must not consult it.
+      const cliRoot = join(root, 'staged', 'node_modules', '@codor', 'cli');
+      mkdirSync(join(cliRoot, 'dist'), { recursive: true });
+      writeFileSync(join(cliRoot, 'dist', 'index.js'), '');
+
+      const previous = process.env.NODE_PATH;
+      process.env.NODE_PATH = hoist;
+      try {
+        expect(defaultInstallIo.probeNative!(cliRoot, process.execPath).ok).toBe(false);
+      } finally {
+        if (previous === undefined) delete process.env.NODE_PATH;
+        else process.env.NODE_PATH = previous;
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  // harn:assume setup-installs-durable-per-user-runtime-atomically ref=durable-runtime-native-probe-resolution
+  it('resolves better-sqlite3 from the switchboard package, not the CLI root', () => {
+    const root = mkdtempSync(join(tmpdir(), 'codor-native-probe-pnpm-'));
+    try {
+      const cliRoot = join(root, 'node_modules', '@codor', 'cli');
+      const switchboardRoot = join(root, 'node_modules', '@codor', 'switchboard');
+      mkdirSync(join(cliRoot, 'dist'), { recursive: true });
+      writeFileSync(join(cliRoot, 'dist', 'index.js'), '');
+      writeFileSync(join(cliRoot, 'package.json'), JSON.stringify({
+        name: '@codor/cli', type: 'module', exports: { '.': './dist/index.js' },
+      }));
+      mkdirSync(join(switchboardRoot, 'dist'), { recursive: true });
+      writeFileSync(join(switchboardRoot, 'dist', 'index.js'), '');
+      writeFileSync(join(switchboardRoot, 'package.json'), JSON.stringify({
+        name: '@codor/switchboard', type: 'module', exports: { '.': './dist/index.js' },
+      }));
+      // better-sqlite3 is nested under switchboard only, so a resolution walk
+      // from the CLI root cannot see it: the probe must resolve from the package
+      // that declares the dependency, as an isolated pnpm layout requires.
+      const database = join(switchboardRoot, 'node_modules', 'better-sqlite3');
+      mkdirSync(database, { recursive: true });
+      writeFileSync(join(database, 'package.json'), JSON.stringify({ name: 'better-sqlite3', main: 'index.js' }));
+      writeFileSync(join(database, 'index.js'), 'module.exports = function Database() { return { close() {} }; };\n');
+
+      expect(defaultInstallIo.probeNative!(cliRoot, process.execPath)).toEqual({ ok: true });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/cli/src/runtime-install.ts
+++ b/packages/cli/src/runtime-install.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { cpSync, existsSync, readFileSync, renameSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, sep } from 'node:path';
@@ -26,6 +27,13 @@ export interface DurableInstallResult {
   transaction?: { backup: string; previousVersion?: string };
 }
 
+/** Outcome of proving a runtime can open a SQLite database under a Node binary. */
+export interface NativeProbeResult {
+  ok: boolean;
+  /** Trimmed child output and error message when `ok` is false. */
+  detail?: string;
+}
+
 /** Injectable filesystem surface so the copy logic is unit-testable. */
 export interface InstallIo {
   exists(path: string): boolean;
@@ -33,6 +41,54 @@ export interface InstallIo {
   move(from: string, to: string): void;
   remove(path: string): void;
   readVersion(packageJsonPath: string): string | undefined;
+  /** Prove the CLI root can open a `better-sqlite3` database under `nodePath`.
+   *  Optional so callers that inject a partial filesystem skip the check; the
+   *  default IO always supplies it. */
+  probeNative?(cliRoot: string, nodePath: string): NativeProbeResult;
+}
+
+/** Opening a database (not an import) is what resolves the native binding;
+ *  `better-sqlite3` defers that to the first `Database` construction. Resolve
+ *  from `@codor/switchboard`, the package that declares the dependency, so an
+ *  isolated pnpm layout works; a CLI-root cwd only finds a hoisted npm layout. */
+const NATIVE_PROBE_SCRIPT = [
+  "import { createRequire } from 'node:module';",
+  'try {',
+  '  const cliRequire = createRequire(process.argv[1]);',
+  "  const switchboard = cliRequire.resolve('@codor/switchboard');",
+  "  const Database = createRequire(switchboard)('better-sqlite3');",
+  "  new Database(':memory:').close();",
+  '} catch (error) {',
+  '  const message = error && error.message ? error.message : String(error);',
+  '  console.error(`better-sqlite3 could not open a database under Node ABI ${process.versions.modules} (${process.platform}-${process.arch}): ${message}`);',
+  '  process.exit(1);',
+  '}',
+].join('\n');
+
+function nativeProbeDetail(error: unknown): string {
+  const details = error as { message?: string; stdout?: unknown; stderr?: unknown };
+  const render = (value: unknown): string => Buffer.isBuffer(value)
+    ? value.toString('utf8')
+    : typeof value === 'string' ? value : '';
+  // Prefer the child's own output. `message` repeats the full command, including
+  // the multi-line probe script, and buries the useful diagnostic.
+  const streams = [render(details.stderr), render(details.stdout)]
+    .map((part) => part.trim())
+    .filter((part) => part !== '');
+  if (streams.length > 0) return streams.join('\n');
+  return details.message?.trim() ?? '';
+}
+
+/** A child environment without NODE_PATH. `createRequire` honors NODE_PATH as a
+ *  CommonJS global path, so an inherited hoist directory (set by pnpm, and
+ *  written into the service environment) could satisfy the probe from the wrong
+ *  tree. */
+function probeEnvironment(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key.toUpperCase() !== 'NODE_PATH') env[key] = value;
+  }
+  return env;
 }
 
 export const defaultInstallIo: InstallIo = {
@@ -48,7 +104,36 @@ export const defaultInstallIo: InstallIo = {
       return undefined;
     }
   },
+  probeNative: (cliRoot, nodePath) => {
+    try {
+      execFileSync(nodePath, [
+        '--input-type=module',
+        '-e',
+        NATIVE_PROBE_SCRIPT,
+        join(cliRoot, 'dist', 'index.js'),
+      ], {
+        cwd: cliRoot,
+        encoding: 'utf8',
+        env: probeEnvironment(),
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, detail: nativeProbeDetail(error) };
+    }
+  },
 };
+
+/** Run the injected native probe, or return undefined when no probe applies
+ *  (a partial IO or a caller that did not name a service Node binary). */
+function probeRuntimeNatives(
+  io: InstallIo,
+  cliRoot: string,
+  nodePath: string | undefined,
+): NativeProbeResult | undefined {
+  if (io.probeNative === undefined || nodePath === undefined) return undefined;
+  return io.probeNative(cliRoot, nodePath);
+}
 
 /** ~/.codor/runtime — the durable per-user runtime location under the data dir. */
 export function durableRuntimeLocation(dataDir: string): string {
@@ -116,7 +201,10 @@ export function detectInstalledRuntime(dataDir: string, io: InstallIo = defaultI
  * re-copies, and `ensure` installs when missing and reuses a matching version. An
  * install or update stages the copy in a sibling directory, validates it, then
  * swaps it in with a backup and rollback, so an interrupted copy never destroys a
- * working install.
+ * working install. A staged copy must also open a SQLite database under the
+ * supplied service Node binary; a tree whose native binding is absent is
+ * discarded before the swap, and a matching installed runtime that fails the
+ * check is not reused.
  */
 export function installDurableRuntime(options: {
   runtime: RuntimePaths;
@@ -124,6 +212,13 @@ export function installDurableRuntime(options: {
   version: string;
   intent?: InstallIntent;
   io?: InstallIo;
+  /** Node binary the service will run. Named so the staged tree can prove its
+   *  native modules load under that exact ABI before the atomic swap. */
+  nodePath?: string;
+  /** Called immediately before the swap moves any existing runtime. A Windows
+   *  service must be quiesced here, because a swap may follow a native-probe
+   *  rejection rather than only an explicit update. */
+  beforeSwap?: () => void;
   retainBackup?: boolean;
 }): DurableInstallResult {
   const io = options.io ?? defaultInstallIo;
@@ -141,9 +236,13 @@ export function installDurableRuntime(options: {
   if (intent === 'keep' && existing !== undefined) {
     return { runtime: installed, location, action: 'reused', version: existing };
   }
-  // Reuse a matching install unless an explicit update was requested.
+  // Reuse a matching install unless an explicit update was requested or the
+  // installed runtime no longer loads its native modules under the service Node.
   if (intent !== 'update' && existing === options.version) {
-    return { runtime: installed, location, action: 'reused', version: options.version };
+    const installedProbe = probeRuntimeNatives(io, installedCliRoot(location), options.nodePath);
+    if (installedProbe === undefined || installedProbe.ok) {
+      return { runtime: installed, location, action: 'reused', version: options.version };
+    }
   }
 
   // Stage the copy in a sibling, validate it, then swap atomically. A failure at
@@ -156,6 +255,19 @@ export function installDurableRuntime(options: {
   if (!io.exists(join(stagedCli, 'dist', 'index.js')) || !io.exists(join(stagedCli, 'runtime', 'web'))) {
     io.remove(staging);
     throw new Error(`the staged Codor runtime at ${staging} is missing its CLI entrypoint or web assets`);
+  }
+  const stagedProbe = probeRuntimeNatives(io, stagedCli, options.nodePath);
+  if (stagedProbe !== undefined && !stagedProbe.ok) {
+    io.remove(staging);
+    throw new Error(
+      `the staged Codor runtime at ${staging} cannot load its better-sqlite3 native binding under ${options.nodePath}: ${stagedProbe.detail ?? 'the database probe failed'}`,
+    );
+  }
+  try {
+    options.beforeSwap?.();
+  } catch (error) {
+    io.remove(staging);
+    throw error;
   }
   if (io.exists(backup)) io.remove(backup);
   if (io.exists(location)) io.move(location, backup);

--- a/packages/cli/src/setup-win32.spec.ts
+++ b/packages/cli/src/setup-win32.spec.ts
@@ -151,6 +151,9 @@ describe('codor setup on Windows', () => {
       writeFileSync(join(cli, 'packaging', 'systemd', 'codor.service'), 'ExecStart=/old\n');
       const installIo: InstallIo = {
         ...defaultInstallIo,
+        // The fabricated runtime has no real native binding; this test exercises
+        // task quiescence, not the native probe.
+        probeNative: () => ({ ok: true }),
         move: (from, to) => {
           if (taskRunning) throw new Error('runtime move attempted while task was running');
           events.push(`move ${from} ${to}`);
@@ -190,6 +193,83 @@ describe('codor setup on Windows', () => {
       expect(firstMove).toBeGreaterThan(1);
       expect(events.slice(0, firstMove).filter((event) => event === 'schtasks /End /TN Codor Switchboard')).toHaveLength(1);
       expect(taskRunning).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  // harn:assume windows-runtime-swap-requires-task-quiescence ref=windows-runtime-quiescence-native-probe
+  it('quiesces the task before swapping a same-version runtime that fails the native probe', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'codor-win32-native-quiesce-'));
+    const commands: string[] = [];
+    const output: string[] = [];
+    const events: string[] = [];
+    let taskRunning = true;
+    try {
+      const overrides = winOptions(root, commands, output);
+      const home = overrides.home;
+      const wrapper = join(root, '_npx', 'candidate', 'node_modules', '@richhardry', 'codor');
+      const cli = join(wrapper, 'node_modules', '@codor', 'cli');
+      mkdirSync(join(cli, 'dist'), { recursive: true });
+      mkdirSync(join(cli, 'runtime', 'web'), { recursive: true });
+      mkdirSync(join(cli, 'packaging', 'systemd'), { recursive: true });
+      writeFileSync(join(wrapper, 'package.json'), JSON.stringify({ version: 'test-version' }));
+      writeFileSync(join(cli, 'package.json'), JSON.stringify({ version: 'test-version' }));
+      writeFileSync(join(cli, 'dist', 'index.js'), '');
+      writeFileSync(join(cli, 'runtime', 'web', 'index.html'), '');
+      writeFileSync(join(cli, 'packaging', 'systemd', 'codor.service'), 'ExecStart=/old\n');
+      // A same-version durable install exists, but its native probe fails. The
+      // reuse is rejected, so the runtime swaps and the task must be quiesced.
+      const installedWrapper = join(home, '.codor', 'runtime', 'node_modules', '@richhardry', 'codor');
+      mkdirSync(installedWrapper, { recursive: true });
+      writeFileSync(join(installedWrapper, 'package.json'), JSON.stringify({ name: '@richhardry/codor', version: 'test-version' }));
+      const installIo: InstallIo = {
+        ...defaultInstallIo,
+        probeNative: (candidateCli) => (candidateCli.includes('.staging')
+          ? { ok: true }
+          : { ok: false, detail: 'Could not locate the bindings file' }),
+        move: (from, to) => {
+          if (taskRunning) throw new Error('runtime move attempted while task was running');
+          events.push(`move ${from} ${to}`);
+          defaultInstallIo.move(from, to);
+        },
+      };
+      overrides.runtime = {
+        layout: 'installed-package',
+        root: cli,
+        cliEntrypoint: join(cli, 'dist', 'index.js'),
+        staticRoot: join(cli, 'runtime', 'web'),
+        serviceTemplate: join(cli, 'packaging', 'systemd', 'codor.service'),
+      };
+      overrides.installIo = installIo;
+      overrides.exec = (command, args) => {
+        const rendered = [command, ...args].join(' ');
+        commands.push(rendered);
+        events.push(rendered);
+        if (command === 'schtasks' && args[0] === '/Query') return '<Task />';
+        if (command === 'schtasks' && args[0] === '/End') taskRunning = false;
+        if (command === 'schtasks' && args[0] === '/Run') taskRunning = true;
+        return '';
+      };
+
+      await runSetup({
+        access: 'localhost',
+        dryRun: false,
+        env: { USERNAME: 'test-user', PATH: 'C:\\Windows\\System32' },
+        out: (line) => output.push(line),
+        overrides,
+        yes: true,
+      });
+
+      expect(commands[0]).toBe('schtasks /Query /TN Codor Switchboard /XML');
+      expect(commands[1]).toBe('schtasks /End /TN Codor Switchboard');
+      const firstMove = events.findIndex((event) => event.startsWith('move '));
+      expect(firstMove).toBeGreaterThan(1);
+      expect(events.slice(0, firstMove).filter((event) => event === 'schtasks /End /TN Codor Switchboard')).toHaveLength(1);
+      expect(taskRunning).toBe(true);
+      // The staged candidate replaced the broken runtime.
+      expect(existsSync(join(home, '.codor', 'runtime', 'node_modules', '@richhardry', 'codor',
+        'node_modules', '@codor', 'cli', 'dist', 'index.js'))).toBe(true);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -867,6 +867,7 @@ export async function waitForCodor(
   sleep: (milliseconds: number) => Promise<void>,
   monotonicNow: () => number = defaultMonotonicNow,
   budgetMs: number = READINESS_BUDGET_MS,
+  logPath?: string,
 ): Promise<void> {
   const startedAt = monotonicNow();
   let delayMs = READINESS_INITIAL_DELAY_MS;
@@ -886,8 +887,11 @@ export async function waitForCodor(
   const budgetLabel = budgetMs === READINESS_BUDGET_MS
     ? '60-second'
     : `${String(budgetMs)} ms`;
+  const guidance = logPath === undefined
+    ? 'run `codor channels` and inspect the user-service logs'
+    : `run \`codor channels\` and inspect the service log at ${logPath}`;
   throw new Error(
-    `Codor did not answer its pairing-status check within the ${budgetLabel} readiness budget at ${endpoint}; run \`codor channels\` and inspect the user-service logs`,
+    `Codor did not answer its pairing-status check within the ${budgetLabel} readiness budget at ${endpoint}; ${guidance}`,
   );
   // harn:end setup-readiness-wait-is-wall-clock-bounded
 }
@@ -954,6 +958,9 @@ export async function runSetup(options: SetupOptions): Promise<void> {
   const launchAgentDir = join(home, 'Library', 'LaunchAgents');
   const launchAgentPath = join(launchAgentDir, `${LAUNCH_AGENT_LABEL}.plist`);
   const logDir = join(dataDir, 'logs');
+  // Linux records service output in the journal; the file-backed platforms write
+  // a codor.err.log the readiness diagnostic can name.
+  const serviceLogPath = platform === 'linux' ? undefined : join(logDir, 'codor.err.log');
   // The service must reference a durable runtime. An ephemeral (npx/temp)
   // invoking runtime is copied to ~/.codor/runtime by the Install step; the
   // service is rendered against that stable copy, while the service template is
@@ -1209,15 +1216,18 @@ export async function runSetup(options: SetupOptions): Promise<void> {
   // Install Codor: make the invoking runtime durable (so the service never
   // references an npx cache), then create the private config, data, and token.
   const installStep = (log: (message: string) => void, intent: InstallIntent = 'ensure'): string => {
-    const existing = detectInstalledRuntime(dataDir, installIo);
-    const swapsRuntime = platform === 'win32'
-      && !installSource.durable
-      && !(intent === 'keep' && existing !== undefined)
-      && !(intent !== 'update' && existing?.version === version);
-    const priorTask = swapsRuntime ? quiesceWindowsTask(exec) : undefined;
+    // Quiesce the Windows task only when the runtime is actually about to swap.
+    // A pure reuse leaves the running service alone; a same-version runtime that
+    // fails the native probe now re-stages and swaps instead of being reused.
+    let priorTask: WindowsTaskSnapshot | undefined;
+    const quiesceBeforeSwap = (): void => {
+      if (platform === 'win32' && priorTask === undefined) priorTask = quiesceWindowsTask(exec);
+    };
     let result;
     try {
-      result = installDurableRuntime({ runtime, dataDir, version, intent, io: installIo });
+      result = installDurableRuntime({
+        runtime, dataDir, version, intent, nodePath, io: installIo, beforeSwap: quiesceBeforeSwap,
+      });
     } catch (error) {
       if (priorTask !== undefined) restartWindowsTask(exec, priorTask);
       throw error;
@@ -1358,7 +1368,7 @@ export async function runSetup(options: SetupOptions): Promise<void> {
     const readinessBudget = options.updateOnly === undefined
       ? READINESS_BUDGET_MS
       : Math.min(READINESS_BUDGET_MS, remainingUpdateMs('candidate readiness'));
-    await waitForCodor(localEndpoint, probe, sleep, updateNow, readinessBudget);
+    await waitForCodor(localEndpoint, probe, sleep, updateNow, readinessBudget, serviceLogPath);
     log('Codor answered its pairing status check');
     if (options.updateOnly !== undefined) remainingUpdateMs('candidate identity verification');
     const selected = await runtimeStatus(localEndpoint, readFileSync(tokenPath, 'utf8').trim());
@@ -1438,6 +1448,7 @@ export async function runSetup(options: SetupOptions): Promise<void> {
         dataDir,
         version,
         intent: 'update',
+        nodePath,
         retainBackup: true,
         io: installIo,
       });
@@ -1491,7 +1502,7 @@ export async function runSetup(options: SetupOptions): Promise<void> {
           if (result === undefined) restartWindowsTask(recoveryExec, priorTask!);
           else restoreWindowsTask(recoveryExec, priorTask!, windowsTaskRestorePath);
         }
-        await waitForCodor(localEndpoint, probe, sleep);
+        await waitForCodor(localEndpoint, probe, sleep, undefined, undefined, serviceLogPath);
         const token = readFileSync(tokenPath, 'utf8').trim();
         const restored = await runtimeStatus(localEndpoint, token);
         if (restored === undefined) {

--- a/packages/cli/src/update.spec.ts
+++ b/packages/cli/src/update.spec.ts
@@ -34,6 +34,15 @@ function missing(): InstallIo {
   };
 }
 
+/** Real filesystem IO with the native probe stubbed for synthetic fixture trees. */
+const stubbedInstallIo: InstallIo = {
+  ...defaultInstallIo,
+  // The update-journey fixtures build synthetic runtime trees and name a
+  // placeholder service node, so the real better-sqlite3 probe cannot succeed.
+  // runtime-install.spec.ts covers the real probe.
+  probeNative: () => ({ ok: true }),
+};
+
 const ok = (stdout = ''): UpdateCommandResult => ({ status: 0, stdout, stderr: '' });
 
 // harn:assume official-codor-update-is-cooperatively-bounded-and-platform-truthful ref=stable-update-regression
@@ -279,6 +288,7 @@ it('updates a previous durable runtime, preserves state, and proves one replacem
         exec: (command, args) => { fixture.commands.push([command, ...args].join(' ')); return command === 'loginctl' ? 'yes' : ''; },
         which: () => undefined,
         probe: async () => true,
+        installIo: stubbedInstallIo,
         runtimeStatus: async () => ({ version: '0.10.12', generation: 'candidate-generation' }),
         sleep: async () => undefined,
       } },
@@ -314,6 +324,7 @@ it('rolls back a candidate whose live service identity does not match', async ()
         exec: (command, args) => { fixture.commands.push([command, ...args].join(' ')); return command === 'loginctl' ? 'yes' : ''; },
         which: () => undefined,
         probe: async () => true,
+        installIo: stubbedInstallIo,
         runtimeStatus: async (_endpoint, _token) => fixture.commands.filter((command) => command === 'systemctl --user restart codor.service').length === 1
           ? { version: '0.10.11', generation: 'stale-generation' }
           : { version: '0.10.11', generation: 'rollback-generation' },
@@ -361,6 +372,7 @@ it('rolls back and reconverges the previous runtime when the candidate restart f
         },
         which: () => undefined,
         probe: async () => true,
+        installIo: stubbedInstallIo,
         runtimeStatus: async () => ({ version: '0.10.11', generation: 'rollback-generation' }),
         sleep: async () => undefined,
       } },
@@ -405,6 +417,7 @@ it('cooperatively times out after service mutation and completes rollback before
           },
           which: () => undefined,
           probe: async () => true,
+          installIo: stubbedInstallIo,
           runtimeStatus: async () => ({ version: '0.10.11', generation: 'prior-generation' }),
           sleep: async () => undefined,
         },
@@ -438,6 +451,7 @@ it('reports a restored legacy daemon as healthy but identity-unverified', async 
         exec: (command, args) => { fixture.commands.push([command, ...args].join(' ')); return command === 'loginctl' ? 'yes' : ''; },
         which: () => undefined,
         probe: async () => true,
+        installIo: stubbedInstallIo,
         runtimeStatus: async () => undefined,
         sleep: async () => undefined,
       } },
@@ -484,6 +498,7 @@ it.each([
         exists: () => true,
         which: () => undefined,
         probe: async () => true,
+        installIo: stubbedInstallIo,
         runtimeStatus: async () => ({ version: '0.10.11', generation: 'prior-generation' }),
         sleep: async () => undefined,
       } },
@@ -505,7 +520,7 @@ it('stops Windows tasks before every runtime move and restores the exact registe
   const priorTaskXml = '<Task><RegistrationInfo><Description>exact prior task</Description></RegistrationInfo></Task>';
   let taskRunning = true;
   const installIo: InstallIo = {
-    ...defaultInstallIo,
+    ...stubbedInstallIo,
     move: (from, to) => {
       if (taskRunning) throw new Error('native runtime is locked by the running task');
       defaultInstallIo.move(from, to);
@@ -555,7 +570,7 @@ it('restarts the untouched Windows task when staging fails before the runtime sw
   const fixture = updateFixture();
   let taskRunning = true;
   const installIo: InstallIo = {
-    ...defaultInstallIo,
+    ...stubbedInstallIo,
     copyTree: () => { throw new Error('candidate staging failed'); },
   };
   try {
@@ -623,6 +638,7 @@ it('leaves a previously absent registered Windows task absent after rollback', a
         },
         which: () => undefined,
         probe: async () => true,
+        installIo: stubbedInstallIo,
         runtimeStatus: async () => ({ version: '0.10.11', generation: 'prior-generation' }),
         sleep: async () => undefined,
       } },
@@ -672,7 +688,7 @@ it.each([
           home: fixture.home,
           nodePath: 'C:\\Program Files\\nodejs\\node.exe',
           platform: 'win32',
-          installIo: { ...defaultInstallIo, copyTree, move },
+          installIo: { ...stubbedInstallIo, copyTree, move },
           exec: (command, args, options) => {
             commands.push({ command, args, timeoutMs: options?.timeoutMs });
             if (command === 'schtasks' && args[0] === '/Query') return query();

--- a/packages/cli/src/update.spec.ts
+++ b/packages/cli/src/update.spec.ts
@@ -64,7 +64,7 @@ describe('runOfficialUpdate', () => {
     expect(out).toHaveBeenCalledWith('Codor 0.10.11 is already current');
   });
 
-  it('acquires one exact release without a shell and invokes only its candidate updater', async () => {
+  it('acquires one exact release, builds the skipped native binding, and invokes only its candidate updater', async () => {
     const prefix = '/tmp/codor-candidate';
     const candidate = join(prefix, 'node_modules/@richhardry/codor/bin/codor.mjs');
     const calls: Array<[string, string[]]> = [];
@@ -75,6 +75,7 @@ describe('runOfficialUpdate', () => {
       return ok();
     });
     const removeTemp = vi.fn();
+    const writeFile = vi.fn();
     const out = vi.fn();
     await runOfficialUpdate({
       dataDir: DATA, env: { PATH: '/usr/bin' }, out,
@@ -83,8 +84,10 @@ describe('runOfficialUpdate', () => {
         installIo: installed(),
         makeTemp: () => prefix,
         removeTemp,
+        writeFile,
         exists: (path) => path === candidate,
         nodePath: '/usr/bin/node',
+        platform: 'linux',
         run,
       },
     });
@@ -92,11 +95,14 @@ describe('runOfficialUpdate', () => {
     expect(calls).toEqual([
       ['npm', ['view', '@richhardry/codor@latest', 'version', '--json', '--registry', 'https://registry.npmjs.org/', '--@richhardry:registry=https://registry.npmjs.org/']],
       ['npm', ['install', '--prefix', prefix, '--ignore-scripts', '--no-audit', '--no-fund', '--no-package-lock', '--no-save', '--registry', 'https://registry.npmjs.org/', '--@richhardry:registry=https://registry.npmjs.org/', '@richhardry/codor@0.10.12']],
+      ['npm', ['rebuild', '--prefix', prefix, 'better-sqlite3']],
       ['/usr/bin/node', [candidate, '--data-dir', DATA, '__apply-update', '--expected-version', '0.10.12', '--timeout-ms', '300000']],
     ]);
     expect(removeTemp).toHaveBeenCalledWith(prefix);
+    expect(writeFile).toHaveBeenCalledWith(join(prefix, '.npmrc'), 'allow-scripts=better-sqlite3\n');
     expect(out).toHaveBeenCalledWith('candidate applied');
-    expect(run.mock.calls[2]?.[2]).not.toHaveProperty('timeoutMs');
+    expect(run.mock.calls[2]?.[2]).toMatchObject({ cwd: prefix });
+    expect(run.mock.calls[3]?.[2]).not.toHaveProperty('timeoutMs');
   });
 
   it('allows a source-linked launcher to update an existing durable installation', async () => {
@@ -146,11 +152,12 @@ describe('runOfficialUpdate', () => {
   it.each([
     { phase: 'lookup', timeout: '11', timeouts: { lookupMs: 11 } },
     { phase: 'acquisition', timeout: '22', timeouts: { acquisitionMs: 22 } },
+    { phase: 'native rebuild', timeout: '33', timeouts: { nativeMs: 33 } },
   ])('bounds $phase execution with an actionable timeout', async ({ phase, timeout, timeouts }) => {
     const prefix = '/tmp/codor-timeout-candidate';
     const candidate = join(prefix, 'node_modules/@richhardry/codor/bin/codor.mjs');
     const run = vi.fn((command: string, args: string[]) => {
-      const current = args[0] === 'view' ? 'lookup' : 'acquisition';
+      const current = args[0] === 'view' ? 'lookup' : args[0] === 'rebuild' ? 'native rebuild' : 'acquisition';
       if (current === phase) return { status: 1, stdout: '', stderr: '', timedOut: true };
       return args[0] === 'view' ? ok('"0.10.12"') : ok();
     });
@@ -158,8 +165,8 @@ describe('runOfficialUpdate', () => {
       dataDir: DATA, env: {}, out: vi.fn(),
       overrides: {
         runtime: RUNTIME, installIo: installed(), makeTemp: () => prefix,
-        removeTemp: vi.fn(), exists: (path) => path === candidate,
-        nodePath: '/usr/bin/node', run, timeouts,
+        removeTemp: vi.fn(), writeFile: vi.fn(), exists: (path) => path === candidate,
+        nodePath: '/usr/bin/node', platform: 'linux', run, timeouts,
       },
     })).rejects.toThrow(new RegExp(`timed out after ${timeout} ms`));
   });

--- a/packages/cli/src/update.ts
+++ b/packages/cli/src/update.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -13,6 +13,8 @@ const EXACT_STABLE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const DEFAULT_TIMEOUTS = {
   lookupMs: 15_000,
   acquisitionMs: 120_000,
+  /** A native rebuild downloads a prebuilt or compiles from source. */
+  nativeMs: 300_000,
   candidateMs: 300_000,
 } as const;
 
@@ -35,7 +37,8 @@ export interface UpdateOverrides {
   exists?(path: string): boolean;
   makeTemp?(): string;
   removeTemp?(path: string): void;
-  run?(command: string, args: string[], options?: { env?: NodeJS.ProcessEnv; timeoutMs?: number }): UpdateCommandResult;
+  writeFile?(path: string, data: string): void;
+  run?(command: string, args: string[], options?: { env?: NodeJS.ProcessEnv; timeoutMs?: number; cwd?: string }): UpdateCommandResult;
   setup?: SetupOverrides;
   applyCandidate?(options: {
     dataDir: string;
@@ -57,13 +60,14 @@ export interface UpdateOptions {
 const defaultRun = (
   command: string,
   args: string[],
-  options: { env?: NodeJS.ProcessEnv; timeoutMs?: number } = {},
+  options: { env?: NodeJS.ProcessEnv; timeoutMs?: number; cwd?: string } = {},
 ): UpdateCommandResult => {
   const result = spawnSync(command, args, {
     encoding: 'utf8',
     env: options.env,
     shell: false,
     stdio: ['ignore', 'pipe', 'pipe'],
+    ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
     ...(options.timeoutMs === undefined ? {} : { timeout: options.timeoutMs }),
   });
   if (result.error) {
@@ -138,10 +142,11 @@ function boundedRun(
   args: string[],
   timeoutMs: number,
   env: NodeJS.ProcessEnv,
+  cwd?: string,
 ): UpdateCommandResult {
   let result: UpdateCommandResult;
   try {
-    result = run(command, args, { env, timeoutMs });
+    result = run(command, args, { env, timeoutMs, ...(cwd === undefined ? {} : { cwd }) });
   } catch (error) {
     throw new Error(`${label}: ${String(error)}`);
   }
@@ -163,6 +168,7 @@ export async function runOfficialUpdate(options: UpdateOptions): Promise<void> {
 
   const run = overrides.run ?? defaultRun;
   const exists = overrides.exists ?? existsSync;
+  const writeFile = overrides.writeFile ?? ((path: string, data: string): void => writeFileSync(path, data, 'utf8'));
   const nodePath = overrides.nodePath ?? process.execPath;
   const timeouts = { ...DEFAULT_TIMEOUTS, ...overrides.timeouts };
   const npm = npmInvocation({
@@ -209,6 +215,21 @@ export async function runOfficialUpdate(options: UpdateOptions): Promise<void> {
       `--@richhardry:registry=${OFFICIAL_REGISTRY}`,
       `${PUBLIC_PACKAGE}@${version}`,
     ], timeouts.acquisitionMs, options.env);
+
+    // `--ignore-scripts` above leaves `better-sqlite3` without the binding its
+    // install script obtains, and the candidate rejects a binding-less tree
+    // before the swap. Rebuild that one dependency so the acquired tree can open
+    // a database under the service Node. Run it from the staging prefix so the
+    // invoker's own project policy cannot block codor's internal dependency.
+    // npm 12 blocks dependency install scripts unless the target project opts in;
+    // the prefix is discarded after the swap, so the allow entry leaks nowhere.
+    // The other native dependencies ship in-package prebuilds and need no script.
+    writeFile(join(prefix, '.npmrc'), 'allow-scripts=better-sqlite3\n');
+    boundedRun(run, `could not build the ${PUBLIC_PACKAGE}@${version} native dependency`, npm.command, [...npm.prefix,
+      'rebuild',
+      '--prefix', prefix,
+      'better-sqlite3',
+    ], timeouts.nativeMs, options.env, prefix);
 
     const candidate = join(prefix, 'node_modules', '@richhardry', 'codor', 'bin', 'codor.mjs');
     if (!exists(candidate)) {

--- a/scripts/packed-install-test.sh
+++ b/scripts/packed-install-test.sh
@@ -122,6 +122,30 @@ case "${1:-}" in
     esac
     exec "$REAL_NPM" install --prefix "$prefix" --ignore-scripts --no-fund --no-package-lock --no-save "$PROOF_UPDATE_TARBALL"
     ;;
+  rebuild)
+    prefix=''
+    previous=''
+    for argument in "$@"; do
+      if [ "$previous" = '--prefix' ]; then prefix="$argument"; fi
+      previous="$argument"
+    done
+    test -n "$prefix"
+    # npm 12 blocks dependency install scripts unless the target project opts
+    # in. Assert the updater wrote the allow entry into the staging prefix
+    # before the rebuild; the container's npm does not enforce that policy, so
+    # this assertion is the only observable proof in the proof harness.
+    if ! grep -Fq 'allow-scripts=better-sqlite3' "$prefix/.npmrc" 2>/dev/null; then
+      printf 'the updater did not opt the staging prefix into install scripts\n' >&2
+      exit 2
+    fi
+    case "$*" in
+      *"better-sqlite3"*) ;;
+      *) printf 'unexpected official native rebuild argv: %s\n' "$*" >&2; exit 2 ;;
+    esac
+    # The acquisition above skips install scripts. Rebuild the one dependency
+    # whose binding that skip removes, exactly as the updater does.
+    exec "$REAL_NPM" rebuild --prefix "$prefix" better-sqlite3
+    ;;
   *) printf 'unexpected npm command: %s\n' "$*" >&2; exit 2 ;;
 esac
 UPDATE_NPM
@@ -173,6 +197,7 @@ UPDATE_SERVER
     test ! -e "$UPDATE_DATA/runtime.backup"
     grep -Fq "view @richhardry/codor@latest version --json" "$UPDATE_NPM_LOG"
     grep -Fq "install --prefix" "$UPDATE_NPM_LOG"
+    grep -Fq "rebuild --prefix" "$UPDATE_NPM_LOG"
     kill "$(cat "$UPDATE_DATA/service.pid")"
     wait "$(cat "$UPDATE_DATA/service.pid")" 2>/dev/null || true
     else


### PR DESCRIPTION
## Problem

`codor install` and `codor update` accepted a staged runtime when `dist/index.js` and `runtime/web` existed. A tree whose package manager skipped the `better-sqlite3` install script passed that check, the registered service crashed on its first database open, and step 4 reported a 60-second readiness timeout that pointed at the readiness probe instead of the missing native binding.

## Result

- The staging branch of `installDurableRuntime` opens an in-memory `better-sqlite3` database with the service Node binary before the atomic swap. A tree whose binding cannot load is discarded with `the staged Codor runtime at … cannot load its better-sqlite3 native binding under <node>: …`, naming the module and the Node ABI. Any existing runtime is left untouched.
- A same-version installed runtime that fails the same probe is no longer reused, so a rerun after the user fixes package-manager approval re-copies instead of keeping the broken runtime.
- A probe-rejected same-version runtime now swaps, so the Windows scheduled task is quiesced lazily through a `beforeSwap` hook that runs immediately before the move. A pure reuse does not stop the service; an explicit update keeps its existing unconditional quiesce.
- The official `codor update` candidate is no longer rejected for the binding its `--ignore-scripts` acquisition skips. The updater rebuilds `better-sqlite3` in the staging prefix, with a staged `.npmrc` allow entry for npm 12, before it invokes the candidate. Without it, every official update failed the new probe.
- The readiness timeout names the file-backed service log (`<data-dir>/logs/codor.err.log`) on Windows and macOS. Linux keeps the journal-based message. No log tail is surfaced, so no redaction path was added.

## Implementation notes

- The probe is injected through the existing `InstallIo` seam (`probeNative`); `defaultInstallIo` supplies the real spawn. Unit tests stay hermetic.
- It opens a database, not just imports the module: `import 'better-sqlite3'` exits 0 on the broken tree because the binding resolves lazily on first `Database` construction.
- It resolves from `@codor/switchboard` (which declares the dependency) via `createRequire`, not from the CLI-root cwd, so an isolated pnpm layout is accepted.
- It runs with `NODE_PATH` removed from the child environment. `createRequire` honors `NODE_PATH` as a CommonJS global path, and both pnpm and the generated service environment set it; otherwise the probe could resolve the dependency from a hoist directory or the installed runtime and validate the wrong tree.
- The failure detail prefers the child's stderr/stdout over the command echo, so it starts with the `better-sqlite3 … Node ABI …` line.
- `runOfficialUpdate` writes `allow-scripts=better-sqlite3` into the staging prefix `.npmrc` and runs a bounded `npm rebuild --prefix <staging> better-sqlite3` from that prefix. npm 12 blocks dependency install scripts by default; the entry is what lets the rebuild produce the binding. The prefix is discarded after the swap, so the entry cannot reach the durable runtime.

## Harn

Touches `setup-installs-durable-per-user-runtime-atomically` (adds a validation step before the atomic swap and rejects a broken same-version reuse; the assumption stays true), `setup-readiness-wait-is-wall-clock-bounded` (message names a log path; the budget is unchanged), `windows-runtime-swap-requires-task-quiescence` (quiescence moves to a `beforeSwap` hook, still before the first move), and `official-codor-update-is-cooperatively-bounded-and-platform-truthful` (acquisition also rebuilds the one native dependency; lookup, bounds, and no-shell invocation are unchanged). `.harn/assumptions/` was not edited.

## Verification

All gates run at the pushed head `9470e1f`.

- `pnpm install --frozen-lockfile` passes.
- `pnpm -r build` passes.
- `pnpm -r test` stops at `@codor/adapter-acp` (`resolves executable files and symlinks but rejects executable-named directories`), a pre-existing Windows failure unrelated to this branch, so it does not reach `@codor/cli`. `@codor/cli` was run directly under Node 26 (the Node that built the `better-sqlite3` binding) with `NODE_PATH` set to the pnpm hoist directory: 279 passed, 10 failed, 18 skipped (307). The same suite at `a222fa3`: 275 passed, 13 failed, 18 skipped (306). The failure set is a strict subset of the parent; no regressions; one test added and three pre-existing `update.spec.ts` cases fixed.
- `update.spec.ts` alone: 22 passed, 3 failed. The three failures (also present at `a222fa3`) are Windows-only: `runOfficialUpdate > is a true no-op when the durable runtime is already latest`, `runOfficialUpdate > rejects prerelease or malformed latest values and cleans failed acquisition staging`, and `rolls back a candidate whose live service identity does not match`. The `update.spec.ts` failures fall from six at `a222fa3` to three.
- Official update candidate on npm 12.0.2 / Node 26.8.1 against a real `@richhardry/codor@0.10.11` acquisition: `npm install --ignore-scripts` leaves 0 bindings; `npm rebuild --prefix <prefix> better-sqlite3` with no `.npmrc` reports `install scripts blocked because they are not covered by allowScripts`, exits 0, and leaves 0 bindings; with the staged `.npmrc` it produces 1 binding and the database probe passes. The `.npmrc` project layer outranks the host's user `allow-scripts` setting.
- Real probe checks: a tree without `better-sqlite3` fails with the module/ABI diagnostic; the installed `~/.codor/runtime` with the absent binding fails with the genuine `Could not locate the bindings file`; a healthy pnpm-isolated tree passes; an empty tree with the hoist directory in `NODE_PATH` returns `ok: false`.
- NOT exercised end to end: a real `codor install` from a binding-less `pnpm dlx` or `npx` tree. The isolated-pnpm resolution is covered by a hermetic test and the real npm-hoisted runtime above.
- NOT exercised end to end: the packed update proof. `scripts/packed-install-test.sh` guards the update subjourney with `if [[ "$CANDIDATE_VERSION" != *-* ]]`, and this branch's artifact is `0.10.14-alpha.2`, so the rebuild path and its new `.npmrc` assertion never run. Routing the prerelease artifact through the stable-latest updater would violate `packed-release-proof-matches-stable-update-policy`; a separate stable-version fixture is required. The proof's `node:22-slim` image (npm 10) also does not enforce the `allowScripts` policy, so even a stable run would not exercise the npm 12 block.
- Known separate defect, deferred and recorded in local notes: on npm 12 `npm view @richhardry/codor@latest version --json` returns `["0.10.11"]`; `stableVersion()` rejects a non-string, so `codor update` fails before acquisition. This PR does not change lookup.
- Known risk: on POSIX the rebuild runs the PATH `npm` Node while the probe uses `nodePath`; if those ABIs differ, the probe rejects the candidate. Windows runs npm under `nodePath`. This PR does not change the ABI source.

Fixes #20.
