### PR TITLE
fix(cli): select the Tailscale Serve origin matching the current device

### DIFF
--- a/packages/cli/src/index.spec.ts
+++ b/packages/cli/src/index.spec.ts
@@ -854,10 +854,13 @@ describe('@codor/cli', () => {
         exec: (command, args) => {
           commands.push([command, ...args].join(' '));
           if (command === 'loginctl') return 'no';
+          if (args.join(' ') === 'status --json') {
+            return JSON.stringify({ Self: { DNSName: 'setup-host.example.ts.net.' } });
+          }
           // Serve is invoked through the resolved absolute path now, not the
           // bare command name; match on the arguments.
           if (args.join(' ') === 'serve status') {
-            return 'https://setup-host.example.ts.net (tailnet only)';
+            return 'https://setup-host.example.ts.net (tailnet only)\n|-- / proxy http://127.0.0.1:8137';
           }
           return '';
         },
@@ -911,6 +914,7 @@ describe('@codor/cli', () => {
     expect(commands).toEqual([
       '/usr/bin/tailscale serve --help',
       '/usr/bin/tailscale serve --bg http://127.0.0.1:8137',
+      '/usr/bin/tailscale status --json',
       '/usr/bin/tailscale serve status',
       'systemctl --user daemon-reload',
       'systemctl --user enable codor.service', 'systemctl --user restart codor.service',

--- a/packages/cli/src/setup-tailscale.spec.ts
+++ b/packages/cli/src/setup-tailscale.spec.ts
@@ -43,18 +43,119 @@ describe('tailscaleServeSupported', () => {
 });
 
 describe('configureTailscaleServe', () => {
-  it('publishes Serve through the resolved absolute path and returns the HTTPS origin', () => {
+  const SELF_STATUS = (dnsName: string): string => JSON.stringify({ Self: { DNSName: dnsName } });
+
+  it('publishes Serve through the resolved absolute path and returns the current HTTPS origin', () => {
     const commands: string[] = [];
     const origin = configureTailscaleServe('/usr/bin/tailscale', 'http://127.0.0.1:8137', (command, args) => {
       commands.push([command, ...args].join(' '));
-      if (args.join(' ') === 'serve status') return 'https://host.tail-abc.ts.net (tailnet only)';
+      if (args.join(' ') === 'status --json') return SELF_STATUS('host.tail-abc.ts.net.');
+      if (args.join(' ') === 'serve status') {
+        return 'https://host.tail-abc.ts.net (tailnet only)\n|-- / proxy http://127.0.0.1:8137';
+      }
       return '';
     });
     expect(origin).toBe('https://host.tail-abc.ts.net');
     expect(commands).toEqual([
       '/usr/bin/tailscale serve --bg http://127.0.0.1:8137',
+      '/usr/bin/tailscale status --json',
       '/usr/bin/tailscale serve status',
     ]);
+  });
+
+  it('selects the current device origin when a stale origin sorts first', () => {
+    const status = [
+      'https://host.tail-abc.ts.net (tailnet only)',
+      '|-- / proxy http://127.0.0.1:8137',
+      '',
+      'https://host.tail-xyz.ts.net (tailnet only)',
+      '|-- / proxy http://127.0.0.1:8137',
+    ].join('\n');
+    const origin = configureTailscaleServe('/usr/bin/tailscale', 'http://127.0.0.1:8137', (_command, args) => {
+      if (args.join(' ') === 'status --json') return SELF_STATUS('host.tail-xyz.ts.net.');
+      if (args.join(' ') === 'serve status') return status;
+      return '';
+    });
+    expect(origin).toBe('https://host.tail-xyz.ts.net');
+  });
+
+  it('names the configured origins and the reset when none matches the current device', () => {
+    const status = [
+      'https://host.tail-abc.ts.net (tailnet only)',
+      '|-- / proxy http://127.0.0.1:8137',
+      '',
+      'https://host.tail-xyz.ts.net (tailnet only)',
+      '|-- / proxy http://127.0.0.1:8137',
+    ].join('\n');
+    let message = '';
+    try {
+      configureTailscaleServe('/usr/bin/tailscale', 'http://127.0.0.1:8137', (_command, args) => {
+        if (args.join(' ') === 'status --json') return SELF_STATUS('host.tail-new.ts.net.');
+        if (args.join(' ') === 'serve status') return status;
+        return '';
+      });
+    } catch (caught) {
+      message = caught instanceof Error ? caught.message : String(caught);
+    }
+    expect(message).toContain('https://host.tail-abc.ts.net');
+    expect(message).toContain('https://host.tail-xyz.ts.net');
+    expect(message).toContain('tailscale serve reset');
+  });
+
+  it('rejects a current-name origin that does not proxy the Codor endpoint', () => {
+    const status = [
+      'https://host.tail-xyz.ts.net (tailnet only)',
+      '|-- / proxy http://127.0.0.1:9999',
+    ].join('\n');
+    expect(() => configureTailscaleServe('/usr/bin/tailscale', 'http://127.0.0.1:8137', (_command, args) => {
+      if (args.join(' ') === 'status --json') return SELF_STATUS('host.tail-xyz.ts.net.');
+      return status;
+    })).toThrow(/does not publish http:\/\/127\.0\.0\.1:8137/);
+  });
+
+  it('ignores a handler that proxies the Codor endpoint below the root path', () => {
+    const status = [
+      'https://host.tail-xyz.ts.net:10443 (tailnet only)',
+      '|-- /codor proxy http://127.0.0.1:8137',
+      '',
+      'https://host.tail-xyz.ts.net (tailnet only)',
+      '|-- / proxy http://127.0.0.1:8137',
+    ].join('\n');
+    const origin = configureTailscaleServe('/usr/bin/tailscale', 'http://127.0.0.1:8137', (_command, args) => {
+      if (args.join(' ') === 'status --json') return SELF_STATUS('host.tail-xyz.ts.net.');
+      if (args.join(' ') === 'serve status') return status;
+      return '';
+    });
+    expect(origin).toBe('https://host.tail-xyz.ts.net');
+  });
+
+  it('does not attach an HTTP handler to the HTTPS origin printed before it', () => {
+    const status = [
+      'https://host.tail-xyz.ts.net (tailnet only)',
+      '|-- / proxy http://127.0.0.1:9999',
+      '',
+      'http://host.tail-xyz.ts.net (tailnet only)',
+      '|-- / proxy http://127.0.0.1:8137',
+    ].join('\n');
+    expect(() => configureTailscaleServe('/usr/bin/tailscale', 'http://127.0.0.1:8137', (_command, args) => {
+      if (args.join(' ') === 'status --json') return SELF_STATUS('host.tail-xyz.ts.net.');
+      if (args.join(' ') === 'serve status') return status;
+      return '';
+    })).toThrow(/does not publish http:\/\/127\.0\.0\.1:8137/);
+  });
+
+  it('fails clearly when the current device name is unreadable', () => {
+    expect(() => configureTailscaleServe('/usr/bin/tailscale', 'http://127.0.0.1:8137', (_command, args) => {
+      if (args.join(' ') === 'status --json') return 'not json';
+      return 'https://host.tail-abc.ts.net (tailnet only)\n|-- / proxy http://127.0.0.1:8137';
+    })).toThrow(/could not read the current device name/);
+  });
+
+  it('labels a status --json failure as a status failure, not a Serve failure', () => {
+    expect(() => configureTailscaleServe('/usr/bin/tailscale', 'http://127.0.0.1:8137', (_command, args) => {
+      if (args.join(' ') === 'status --json') throw new Error('tailscale status: not running');
+      return '';
+    })).toThrow(/Tailscale status command failed: tailscale status: not running/);
   });
 
   it('throws a distinct "Serve command failed" diagnostic when the serve command fails', () => {
@@ -101,14 +202,17 @@ describe('configureTailscaleServe', () => {
 
   it('wraps a serve status command failure as the Serve-command-failed category', () => {
     expect(() => configureTailscaleServe('/usr/bin/tailscale', 'http://127.0.0.1:8137', (_command, args) => {
+      if (args.join(' ') === 'status --json') return SELF_STATUS('host.tail-abc.ts.net.');
       if (args.join(' ') === 'serve status') throw new Error('serve status: connection refused');
       return '';
     })).toThrow(/Serve command failed: serve status: connection refused/);
   });
 
   it('throws when serve status reports no HTTPS origin', () => {
-    expect(() => configureTailscaleServe('/usr/bin/tailscale', 'http://127.0.0.1:8137', () => 'no serve config'))
-      .toThrow(/did not report a private HTTPS origin/);
+    expect(() => configureTailscaleServe('/usr/bin/tailscale', 'http://127.0.0.1:8137', (_command, args) => {
+      if (args.join(' ') === 'status --json') return SELF_STATUS('host.tail-abc.ts.net.');
+      return 'no serve config';
+    })).toThrow(/did not report a private HTTPS origin/);
   });
 
   // harn:assume setup-bounds-tailscale-serve-consent-and-keeps-diagnostics-actionable ref=tailscale-serve-consent-regression
@@ -127,15 +231,19 @@ describe('configureTailscaleServe', () => {
     })).toThrow(/https:\/\/login\.tailscale\.com\/f\/https/);
   });
 
-  it('bounds the serve --bg call with a timeout but leaves serve status unbounded', () => {
+  it('bounds the serve --bg call with a timeout but leaves later reads unbounded', () => {
     const calls: Array<{ args: string[]; options: { timeoutMs?: number } | undefined }> = [];
     configureTailscaleServe('/usr/bin/tailscale', 'http://127.0.0.1:8137', (_command, args, options) => {
       calls.push({ args, options });
-      if (args.join(' ') === 'serve status') return 'https://host.tail-abc.ts.net (tailnet only)';
+      if (args.join(' ') === 'status --json') return SELF_STATUS('host.tail-abc.ts.net.');
+      if (args.join(' ') === 'serve status') {
+        return 'https://host.tail-abc.ts.net (tailnet only)\n|-- / proxy http://127.0.0.1:8137';
+      }
       return '';
     });
     expect(calls[0]).toEqual({ args: ['serve', '--bg', 'http://127.0.0.1:8137'], options: { timeoutMs: 20_000 } });
-    expect(calls[1]).toEqual({ args: ['serve', 'status'], options: undefined });
+    expect(calls[1]).toEqual({ args: ['status', '--json'], options: undefined });
+    expect(calls[2]).toEqual({ args: ['serve', 'status'], options: undefined });
   });
   // harn:end setup-bounds-tailscale-serve-consent-and-keeps-diagnostics-actionable
 });

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -465,9 +465,65 @@ export function tailscaleServeSupported(
   }
 }
 
+/** One Web origin from `tailscale serve status`, with its root-path proxy targets. */
+interface ServeOrigin {
+  scheme: 'http' | 'https';
+  /** The `host[:port]` authority exactly as printed. */
+  authority: string;
+  /** The authority with any port removed, compared against `Self.DNSName`. */
+  host: string;
+  /** Targets proxied from the root `/` handler only. */
+  proxies: string[];
+}
+
+/** Parse `tailscale serve status` text into its Web origins. The format is an
+ *  origin line per scheme/host/port, followed by `|-- <path> proxy <target>`
+ *  handler lines; the next origin line closes the previous origin, so an HTTP
+ *  handler never attaches to the HTTPS origin printed before it. */
+function parseServeOrigins(status: string): ServeOrigin[] {
+  const origins: ServeOrigin[] = [];
+  let current: ServeOrigin | undefined;
+  for (const raw of status.split(/\r?\n/)) {
+    const line = raw.trim();
+    const origin = line.match(/^(https?):\/\/([^\s/]+)/);
+    if (origin !== null) {
+      const scheme = origin[1];
+      const authority = origin[2];
+      if ((scheme !== 'http' && scheme !== 'https') || authority === undefined) continue;
+      current = { scheme, authority, host: authority.replace(/:\d+$/, ''), proxies: [] };
+      origins.push(current);
+      continue;
+    }
+    if (current === undefined || current.scheme !== 'https') continue;
+    const handler = line.match(/^\|--\s+(\S+)\s+(proxy|path|text)\s+(\S.*)$/);
+    if (handler === null) continue;
+    const mount = handler[1];
+    const type = handler[2];
+    const target = handler[3];
+    if (mount === '/' && type === 'proxy' && target !== undefined) current.proxies.push(target.trim());
+  }
+  return origins;
+}
+
+/** The current device FQDN from `tailscale status --json`, trailing dot removed. */
+function tailscaleSelfDnsName(statusJson: string): string | undefined {
+  try {
+    const parsed = JSON.parse(statusJson) as { Self?: { DNSName?: unknown } };
+    const name = parsed.Self?.DNSName;
+    if (typeof name !== 'string') return undefined;
+    const trimmed = name.trim().replace(/\.$/, '');
+    return trimmed === '' ? undefined : trimmed;
+  } catch {
+    return undefined;
+  }
+}
+
 // harn:assume setup-bounds-tailscale-serve-consent-and-keeps-diagnostics-actionable ref=tailscale-serve-consent-command
-/** Publish Serve through the resolved absolute path and return the HTTPS origin.
- *  Throws a distinct diagnostic when the serve command itself fails. */
+/** Publish Serve through the resolved absolute path and return the HTTPS origin
+ *  whose host matches the current device. Throws a distinct diagnostic when the
+ *  serve command fails, and when no published origin matches `Self.DNSName`.
+ *  `serve status` keeps a handler keyed by an old MagicDNS name after a tailnet
+ *  rename and can list it first, so the current device name decides. */
 export function configureTailscaleServe(
   tailscalePath: string,
   localEndpoint: string,
@@ -489,18 +545,44 @@ export function configureTailscaleServe(
     return parts.join('\n').trim() || String(error);
   };
   let status: string;
+  let statusJson: string;
   try {
     // Bounded: when the tailnet has no HTTPS certificates enabled, `serve --bg`
     // does not fail — it blocks waiting for interactive consent in a browser.
     // `serve status` never blocks this way, so only the first call gets a budget.
     exec(tailscalePath, ['serve', '--bg', localEndpoint], { timeoutMs: 20_000 });
+  } catch (error) {
+    throw new Error(`Tailscale Serve command failed: ${diagnostic(error)}`);
+  }
+  try {
+    // The current device name is the source of truth for origin selection; a
+    // stale Serve origin can sort first after a tailnet DNS rename.
+    statusJson = exec(tailscalePath, ['status', '--json']);
+  } catch (error) {
+    throw new Error(`Tailscale status command failed: ${diagnostic(error)}`);
+  }
+  try {
     status = exec(tailscalePath, ['serve', 'status']);
   } catch (error) {
     throw new Error(`Tailscale Serve command failed: ${diagnostic(error)}`);
   }
-  const origin = status.match(/https:\/\/[^\s/]+/)?.[0];
-  if (origin === undefined) throw new Error('Tailscale Serve did not report a private HTTPS origin');
-  return origin;
+  const host = tailscaleSelfDnsName(statusJson);
+  if (host === undefined) {
+    throw new Error('Tailscale Serve could not read the current device name from `tailscale status --json`');
+  }
+  const httpsOrigins = parseServeOrigins(status).filter((origin) => origin.scheme === 'https');
+  if (httpsOrigins.length === 0) throw new Error('Tailscale Serve did not report a private HTTPS origin');
+  const match = httpsOrigins.find((origin) =>
+    origin.host.toLowerCase() === host.toLowerCase() && origin.proxies.includes(localEndpoint),
+  );
+  if (match === undefined) {
+    const listed = httpsOrigins.map((origin) => `https://${origin.authority}`).join(', ');
+    throw new Error(
+      `Tailscale Serve does not publish ${localEndpoint} at ${host}; configured origins: ${listed}. ` +
+        '`tailscale serve reset` clears all Serve config on this node; re-run install to publish the current name',
+    );
+  }
+  return `https://${match.authority}`;
 }
 // harn:end setup-bounds-tailscale-serve-consent-and-keeps-diagnostics-actionable
 // harn:end setup-resolves-and-capability-probes-tailscale-serve
@@ -1111,6 +1193,7 @@ export async function runSetup(options: SetupOptions): Promise<void> {
     }
     if (access === 'tailscale') {
       options.out('[dry-run] tailscale serve --bg http://127.0.0.1:8137');
+      options.out('[dry-run] tailscale status --json');
       options.out('[dry-run] tailscale serve status');
     } else {
       options.out('[dry-run] access localhost; skip Tailscale Serve');


### PR DESCRIPTION
Fixes #24.

## Problem

With Tailscale Serve access, `codor install` builds the pairing link from the first `https://` origin
in `tailscale serve status`. After a tailnet DNS rename, Tailscale keeps the Serve handler keyed by the
old MagicDNS name and lists it first, so the link and its `?endpoint=` parameter carry a hostname that
no longer resolves. Codor never reads the node's current `Self.DNSName`, so `serve status` order alone
decides the endpoint.

## Result

The pairing origin is now the HTTPS origin whose host matches the current device name and whose root
handler proxies to Codor, regardless of the order `serve status` prints.

## Implementation

- Read the current device FQDN from `tailscale status --json` `Self.DNSName` (trailing dot removed).
  An unreadable or absent name fails with its own diagnostic.
- Parse `tailscale serve status` text into per-origin root-path proxy targets.
- Select the HTTPS origin whose host matches `Self.DNSName` and whose `/` handler proxies to the local
  endpoint.
- No match fails with a diagnostic that names every HTTPS origin and states that `tailscale serve reset`
  clears all Serve config on the node. Zero HTTPS origins keeps the existing "did not report a private
  HTTPS origin" message.
- A `tailscale status --json` failure now reports "Tailscale status command failed" instead of the Serve
  label.
- The dry-run transcript prints the `tailscale status --json` read.

### Parser scope

Matches Tailscale's port/path granularity, checked against `cmd/tailscale/cli/serve_legacy.go` and
`cmd/tailscale/cli/serve_status.go` at v1.102.4:

- an origin line of either scheme closes the previous origin, so an HTTP handler cannot attach to the
  HTTPS origin printed before it;
- only the root `/` handler qualifies, so a `/sub` proxy does not;
- Web origins print in sorted HostPort order, which is why `host:10443` can precede `host` on 443, and
  why order alone is not authoritative.

## Compatibility decision

Codor's serve command publishes the root handler on HTTPS 443, so the HTTPS-only, root-only match
reflects what Codor itself created. This adds a dependency on the `tailscale status --json` shape. The
read degrades to a clear failure, never a silent stale pick.

## Harn

Touches `setup-bounds-tailscale-serve-consent-and-keeps-diagnostics-actionable`, nested in
`setup-resolves-and-capability-probes-tailscale-serve`. The bounds contract stays intact: only
`serve --bg` is bounded; `status --json` and `serve status` stay unbounded. `.harn/` is not edited.

## Tests

```sh
pnpm install --frozen-lockfile
pnpm -r build
cd packages/cli
pnpm exec vitest run src/setup-tailscale.spec.ts   # 21 passed
pnpm exec vitest run                               # 11 failed | 275 passed | 18 skipped
```

- `setup-tailscale.spec.ts` passes, including 7 new cases: stale-first two-origin selection, all-origins
  no-match diagnostic, current-name wrong-proxy rejection, unreadable device name, non-root `/sub`
  ignored, HTTP-handler boundary, and the `status --json` failure label.
- Whole-CLI suite, Windows 11 only: the branch run is 11 failed | 275 passed | 18 skipped. A targeted
  baseline run on unmodified `main` (`03481a3`) reproduced the same 11 failures, 5 in
  `launcher-install.spec.ts` and 6 in `update.spec.ts`. Earlier runs also reported an `index.spec.ts`
  worktree lifecycle timeout that did not recur. None of the failures is Tailscale-related. The suite
  total grows from 297 to 304, the 7 new cases.
- `pnpm -r test` aborts in `packages/adapters/antigravity` on Windows before reaching `@codor/cli`. CI
  runs `pnpm -r --workspace-concurrency=1 test` on Ubuntu; that gate was not run on this platform.

## Not tested

- Platform: Windows 11 only. The `index.spec.ts` setup integration case is `posixHostIt`-guarded, so it
  did not execute here; the parser cases run on every platform.
- Real device: a live rename-and-install cannot be reproduced on the repro node now because
  `tailscale serve reset` removed the old handler. Stale-first selection is unit-tested.
- A live single-origin probe on this node (Tailscale 1.102.4, Windows) returned
  `https://<device>.<current-tailnet>.ts.net` with the call order `serve --bg`, `status --json`,
  `serve status`.