### PR TITLE
fix(cli): replace the launcher path entry instead of writing through a symlink

### DIFF
--- a/packages/cli/src/launcher-install.spec.ts
+++ b/packages/cli/src/launcher-install.spec.ts
@@ -1,4 +1,4 @@
-import { lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
+import { lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -47,6 +47,12 @@ function fakeIo(seed: Record<string, string> = {}): FakeIo {
       }
       symlinks.delete(to); // rename replaces the destination entry
     },
+    remove: (path) => {
+      files.delete(path);
+      modes.delete(path);
+      symlinks.delete(path);
+      dirs.delete(path);
+    },
     mkdirp: (path) => void dirs.add(path),
     chmod: (path, mode) => void modes.set(path, mode),
     isSymlink: (path) => symlinks.has(path),
@@ -90,6 +96,23 @@ describe('installLauncherShim', () => {
     const result = installLauncherShim({ home: HOME, nodePath: '/opt/node', cliEntrypoint: ENTRY, io });
     expect(result.action).toBe('updated');
     expect(io.files.get(LAUNCHER)).toContain('/opt/node');
+  });
+
+  // Requirement: a cleanup failure must not replace the error that triggered it.
+  // Not covered by the real-filesystem cleanup test, whose cleanup succeeds.
+  it('preserves the primary error when the staged-file cleanup also fails', () => {
+    const io = fakeIo();
+    const primary = new Error('rename failed');
+    io.rename = () => { throw primary; };
+    io.remove = () => { throw new Error('cleanup failed'); };
+
+    let caught: unknown;
+    try {
+      installLauncherShim({ home: HOME, nodePath: NODE, cliEntrypoint: ENTRY, io });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBe(primary);
   });
 });
 
@@ -203,6 +226,23 @@ describe('installLauncherShim on a real filesystem', () => {
       expect(readFileSync(decoy, 'utf8')).toBe('// decoy\n');
       expect(lstatSync(legacyTmp).isSymbolicLink()).toBe(true);
       expect(lstatSync(join(bin, 'codor')).isSymbolicLink()).toBe(false);
+    });
+  });
+
+  // Requirement: a failed write or rename must not leave the staged launcher
+  // behind. The path is occupied by a directory so rename fails; a leftover
+  // `codor.tmp-<uuid>` there would accumulate on every failed attempt.
+  posixHostIt('removes the staged file when the rename fails', () => {
+    withTempHome((home) => {
+      const bin = join(home, '.local', 'bin');
+      const launcher = join(bin, 'codor');
+      mkdirSync(launcher, { recursive: true }); // a directory blocks the rename
+
+      expect(() => installLauncherShim({ home, nodePath: '/usr/bin/node', cliEntrypoint: '/tmp/entry.js' })).toThrow();
+
+      const leftovers = readdirSync(bin).filter((name) => name.startsWith('codor.tmp-'));
+      expect(leftovers).toEqual([]);
+      expect(lstatSync(launcher).isDirectory()).toBe(true);
     });
   });
 });

--- a/packages/cli/src/launcher-install.spec.ts
+++ b/packages/cli/src/launcher-install.spec.ts
@@ -1,4 +1,4 @@
-import { lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -15,16 +15,19 @@ interface FakeIo extends LauncherIo {
   files: Map<string, string>;
   dirs: Set<string>;
   modes: Map<string, number>;
+  symlinks: Set<string>;
 }
 
 function fakeIo(seed: Record<string, string> = {}): FakeIo {
   const files = new Map(Object.entries(seed));
   const dirs = new Set<string>();
   const modes = new Map<string, number>();
+  const symlinks = new Set<string>();
   return {
     files,
     dirs,
     modes,
+    symlinks,
     exists: (path) => files.has(path) || dirs.has(path),
     read: (path) => files.get(path),
     write: (path, content, mode) => {
@@ -42,9 +45,11 @@ function fakeIo(seed: Record<string, string> = {}): FakeIo {
         modes.set(to, mode);
         modes.delete(from);
       }
+      symlinks.delete(to); // rename replaces the destination entry
     },
     mkdirp: (path) => void dirs.add(path),
     chmod: (path, mode) => void modes.set(path, mode),
+    isSymlink: (path) => symlinks.has(path),
   };
 }
 
@@ -127,13 +132,21 @@ describe('ensureLocalBinOnPath', () => {
 
 const posixHostIt = it.skipIf(process.platform === 'win32');
 
+function withTempHome(run: (home: string) => void): void {
+  const home = mkdtempSync(join(tmpdir(), 'codor-launcher-symlink-'));
+  try {
+    run(home);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
 describe('installLauncherShim on a real filesystem', () => {
   // Requirement: refreshing the launcher replaces the ~/.local/bin/codor path entry
   // and never writes through a symlink to its target. Not redundant with the
   // in-memory tests above, whose Map cannot represent a symlink.
   posixHostIt('replaces a pre-existing symlink without touching its target', () => {
-    const home = mkdtempSync(join(tmpdir(), 'codor-launcher-symlink-'));
-    try {
+    withTempHome((home) => {
       const bin = join(home, '.local', 'bin');
       mkdirSync(bin, { recursive: true });
       const entrypoint = join(home, 'cli-entrypoint.js');
@@ -146,8 +159,50 @@ describe('installLauncherShim on a real filesystem', () => {
       expect(readFileSync(entrypoint, 'utf8')).toBe('// compiled CLI entrypoint\n');
       expect(lstatSync(join(bin, 'codor')).isSymbolicLink()).toBe(false);
       expect(readFileSync(join(bin, 'codor'), 'utf8')).toBe(launcherShim('/usr/bin/node', entrypoint));
-    } finally {
-      rmSync(home, { recursive: true, force: true });
-    }
+    });
+  });
+
+  // Requirement: a symlink is never "unchanged", even when its target already holds
+  // the shim. The content check alone would leave the link in place and chmod its
+  // target; only an lstat-first check replaces the entry. Not covered above.
+  posixHostIt('replaces a symlink whose target already holds the desired shim', () => {
+    withTempHome((home) => {
+      const bin = join(home, '.local', 'bin');
+      mkdirSync(bin, { recursive: true });
+      const nodePath = '/usr/bin/node';
+      const entrypoint = '/tmp/entry.js';
+      const target = join(home, 'shim-copy');
+      writeFileSync(target, launcherShim(nodePath, entrypoint), { mode: 0o644 });
+      const before = statSync(target).mode;
+      symlinkSync(target, join(bin, 'codor'));
+
+      const result = installLauncherShim({ home, nodePath, cliEntrypoint: entrypoint });
+
+      expect(result.action).toBe('updated');
+      expect(lstatSync(join(bin, 'codor')).isSymbolicLink()).toBe(false);
+      expect(readFileSync(target, 'utf8')).toBe(launcherShim(nodePath, entrypoint));
+      expect(statSync(target).mode).toBe(before); // chmod must not follow the link
+    });
+  });
+
+  // Requirement: a pre-existing symlink at the staging path is never written
+  // through. A predictable staging name let that symlink's target be overwritten
+  // and the link itself renamed onto ~/.local/bin/codor. Not covered above.
+  posixHostIt('does not write through a symlink planted at the legacy staging path', () => {
+    withTempHome((home) => {
+      const bin = join(home, '.local', 'bin');
+      mkdirSync(bin, { recursive: true });
+      const decoy = join(home, 'decoy.js');
+      writeFileSync(decoy, '// decoy\n', { mode: 0o755 });
+      const legacyTmp = join(bin, 'codor.tmp');
+      symlinkSync(decoy, legacyTmp);
+
+      const result = installLauncherShim({ home, nodePath: '/usr/bin/node', cliEntrypoint: '/tmp/entry.js' });
+
+      expect(result.action).toBe('created');
+      expect(readFileSync(decoy, 'utf8')).toBe('// decoy\n');
+      expect(lstatSync(legacyTmp).isSymbolicLink()).toBe(true);
+      expect(lstatSync(join(bin, 'codor')).isSymbolicLink()).toBe(false);
+    });
   });
 });

--- a/packages/cli/src/launcher-install.spec.ts
+++ b/packages/cli/src/launcher-install.spec.ts
@@ -1,3 +1,7 @@
+import { lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -26,6 +30,18 @@ function fakeIo(seed: Record<string, string> = {}): FakeIo {
     write: (path, content, mode) => {
       files.set(path, content);
       if (mode !== undefined) modes.set(path, mode);
+    },
+    rename: (from, to) => {
+      const content = files.get(from);
+      if (content !== undefined) {
+        files.set(to, content);
+        files.delete(from);
+      }
+      const mode = modes.get(from);
+      if (mode !== undefined) {
+        modes.set(to, mode);
+        modes.delete(from);
+      }
     },
     mkdirp: (path) => void dirs.add(path),
     chmod: (path, mode) => void modes.set(path, mode),
@@ -106,5 +122,32 @@ describe('ensureLocalBinOnPath', () => {
     expect(result.wrote).toBe(false);
     expect(io.files.has(ZPROFILE)).toBe(false);
     expect(logs.join(' ')).toMatch(/PATH/);
+  });
+});
+
+const posixHostIt = it.skipIf(process.platform === 'win32');
+
+describe('installLauncherShim on a real filesystem', () => {
+  // Requirement: refreshing the launcher replaces the ~/.local/bin/codor path entry
+  // and never writes through a symlink to its target. Not redundant with the
+  // in-memory tests above, whose Map cannot represent a symlink.
+  posixHostIt('replaces a pre-existing symlink without touching its target', () => {
+    const home = mkdtempSync(join(tmpdir(), 'codor-launcher-symlink-'));
+    try {
+      const bin = join(home, '.local', 'bin');
+      mkdirSync(bin, { recursive: true });
+      const entrypoint = join(home, 'cli-entrypoint.js');
+      writeFileSync(entrypoint, '// compiled CLI entrypoint\n', { mode: 0o755 });
+      symlinkSync(entrypoint, join(bin, 'codor'));
+
+      const result = installLauncherShim({ home, nodePath: '/usr/bin/node', cliEntrypoint: entrypoint });
+
+      expect(result.action).toBe('updated');
+      expect(readFileSync(entrypoint, 'utf8')).toBe('// compiled CLI entrypoint\n');
+      expect(lstatSync(join(bin, 'codor')).isSymbolicLink()).toBe(false);
+      expect(readFileSync(join(bin, 'codor'), 'utf8')).toBe(launcherShim('/usr/bin/node', entrypoint));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/src/launcher-install.ts
+++ b/packages/cli/src/launcher-install.ts
@@ -1,4 +1,5 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 /** Injectable filesystem surface so the launcher logic is unit-testable. `home` and
@@ -11,6 +12,7 @@ export interface LauncherIo {
   rename(from: string, to: string): void;
   mkdirp(path: string, mode: number): void;
   chmod(path: string, mode: number): void;
+  isSymlink(path: string): boolean;
 }
 
 export const defaultLauncherIo: LauncherIo = {
@@ -26,6 +28,13 @@ export const defaultLauncherIo: LauncherIo = {
   rename: (from, to) => renameSync(from, to),
   mkdirp: (path, mode) => { mkdirSync(path, { recursive: true, mode }); },
   chmod: (path, mode) => chmodSync(path, mode),
+  isSymlink: (path) => {
+    try {
+      return lstatSync(path).isSymbolicLink();
+    } catch {
+      return false;
+    }
+  },
 };
 
 export type LauncherAction = 'created' | 'updated' | 'unchanged';
@@ -62,13 +71,18 @@ export function installLauncherShim(options: {
   io.mkdirp(dir, 0o700);
   const desired = launcherShim(options.nodePath, options.cliEntrypoint);
   const existing = io.read(path);
-  if (existing === desired) {
+  // A symlink is never "unchanged", even when its target already holds the shim:
+  // the path entry itself must become the regular launcher file. `read` follows
+  // the link, so check the entry with lstat before trusting the content match.
+  if (!io.isSymlink(path) && existing === desired) {
     io.chmod(path, 0o755); // keep it executable even when the content already matches
     return { path, action: 'unchanged' };
   }
   // Stage a sibling and rename it into place: rename replaces the path entry
   // itself, so a pre-existing symlink is replaced rather than written through.
-  const staged = `${path}.tmp`;
+  // The random name keeps the staging path unpredictable, so a pre-existing
+  // symlink cannot be planted there and written through.
+  const staged = `${path}.tmp-${randomUUID()}`;
   io.write(staged, desired, 0o755);
   io.rename(staged, path);
   return { path, action: existing === undefined ? 'created' : 'updated' };

--- a/packages/cli/src/launcher-install.ts
+++ b/packages/cli/src/launcher-install.ts
@@ -80,8 +80,8 @@ export function installLauncherShim(options: {
   }
   // Stage a sibling and rename it into place: rename replaces the path entry
   // itself, so a pre-existing symlink is replaced rather than written through.
-  // The random name keeps the staging path unpredictable, so a pre-existing
-  // symlink cannot be planted there and written through.
+  // The UUID suffix avoids reuse of the former predictable `codor.tmp` path; it
+  // makes a collision negligible, not impossible.
   const staged = `${path}.tmp-${randomUUID()}`;
   io.write(staged, desired, 0o755);
   io.rename(staged, path);

--- a/packages/cli/src/launcher-install.ts
+++ b/packages/cli/src/launcher-install.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 /** Injectable filesystem surface so the launcher logic is unit-testable. `home` and
@@ -8,6 +8,7 @@ export interface LauncherIo {
   exists(path: string): boolean;
   read(path: string): string | undefined;
   write(path: string, content: string, mode?: number): void;
+  rename(from: string, to: string): void;
   mkdirp(path: string, mode: number): void;
   chmod(path: string, mode: number): void;
 }
@@ -22,6 +23,7 @@ export const defaultLauncherIo: LauncherIo = {
     }
   },
   write: (path, content, mode) => writeFileSync(path, content, mode === undefined ? undefined : { mode }),
+  rename: (from, to) => renameSync(from, to),
   mkdirp: (path, mode) => { mkdirSync(path, { recursive: true, mode }); },
   chmod: (path, mode) => chmodSync(path, mode),
 };
@@ -64,7 +66,11 @@ export function installLauncherShim(options: {
     io.chmod(path, 0o755); // keep it executable even when the content already matches
     return { path, action: 'unchanged' };
   }
-  io.write(path, desired, 0o755);
+  // Stage a sibling and rename it into place: rename replaces the path entry
+  // itself, so a pre-existing symlink is replaced rather than written through.
+  const staged = `${path}.tmp`;
+  io.write(staged, desired, 0o755);
+  io.rename(staged, path);
   return { path, action: existing === undefined ? 'created' : 'updated' };
 }
 // harn:end setup-installs-user-launcher-shim

--- a/packages/cli/src/launcher-install.ts
+++ b/packages/cli/src/launcher-install.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 /** Injectable filesystem surface so the launcher logic is unit-testable. `home` and
@@ -10,6 +10,7 @@ export interface LauncherIo {
   read(path: string): string | undefined;
   write(path: string, content: string, mode?: number): void;
   rename(from: string, to: string): void;
+  remove(path: string): void;
   mkdirp(path: string, mode: number): void;
   chmod(path: string, mode: number): void;
   isSymlink(path: string): boolean;
@@ -26,6 +27,7 @@ export const defaultLauncherIo: LauncherIo = {
   },
   write: (path, content, mode) => writeFileSync(path, content, mode === undefined ? undefined : { mode }),
   rename: (from, to) => renameSync(from, to),
+  remove: (path) => { rmSync(path, { force: true }); },
   mkdirp: (path, mode) => { mkdirSync(path, { recursive: true, mode }); },
   chmod: (path, mode) => chmodSync(path, mode),
   isSymlink: (path) => {
@@ -83,8 +85,19 @@ export function installLauncherShim(options: {
   // The UUID suffix avoids reuse of the former predictable `codor.tmp` path; it
   // makes a collision negligible, not impossible.
   const staged = `${path}.tmp-${randomUUID()}`;
-  io.write(staged, desired, 0o755);
-  io.rename(staged, path);
+  try {
+    io.write(staged, desired, 0o755);
+    io.rename(staged, path);
+  } catch (error) {
+    // Best-effort cleanup after a failed write or rename. A cleanup failure must
+    // not replace the error that callers need to see, so it is swallowed.
+    try {
+      io.remove(staged);
+    } catch {
+      // The staging file is abandoned; the original error remains the signal.
+    }
+    throw error;
+  }
   return { path, action: existing === undefined ? 'created' : 'updated' };
 }
 // harn:end setup-installs-user-launcher-shim


### PR DESCRIPTION
## Problem

`codor install` (step 2, "Install Codor") writes `~/.local/bin/codor` with `writeFileSync`. When that path is already a symlink, the write follows the link and replaces the link target.

The documented source installer, `scripts/install-cli.sh`, creates exactly that symlink to `packages/cli/dist/index.js`. Running the two documented steps in order replaces the compiled entrypoint with the shell shim. `codor --version` and the LaunchAgent then fail with `SyntaxError: Invalid or unexpected token`, the service crash-loops, and wizard step 4 times out: `Codor did not answer its pairing-status check within the 60-second readiness budget at http://127.0.0.1:8137`.

Fixes #26.

## Intended result

The launcher install replaces `~/.local/bin/codor` itself and never modifies the file a pre-existing symlink points to. The compiled entrypoint stays intact.

## Implementation

`packages/cli/src/launcher-install.ts` (`installLauncherShim`):

- Stage the shim at a sibling `~/.local/bin/codor.tmp-${randomUUID()}` and `rename` it over the path. `rename` replaces the path entry itself; it does not follow a symlink.
- Treat a symlink as never `unchanged`, even when its target already holds the shim. `io.read` follows the link, so an `lstat` check (`io.isSymlink`) runs before the content-equality shortcut. Without it, the link would remain and `chmod` would change its target's mode.
- The UUID suffix avoids reuse of the former predictable `codor.tmp` path. Each temporary file is newly created with executable permissions, subject to the process umask.
- Attempt best-effort cleanup after a failed write or rename. Successful cleanup prevents accumulation. Cleanup errors are swallowed so the primary error propagates.

`LauncherIo` gains `rename`, `isSymlink`, and `remove`; `defaultLauncherIo` implements them with `renameSync`, `lstatSync`, and `rmSync(path, { force: true })`.

Intended behavior change for `harn:assume setup-installs-user-launcher-shim`: the launcher install replaces the path entry itself and never writes through a symlink. Harn hashes not edited; `.harn/assumptions/` is unchanged.

## Tests

`packages/cli/src/launcher-install.spec.ts`:

- Real-filesystem: symlink `~/.local/bin/codor` to a fixture entrypoint, run `installLauncherShim`, assert the fixture is unchanged and the path is a regular file with the shim.
- Real-filesystem: symlink whose target already holds the shim — assert `updated`, regular file, target content and mode untouched.
- Real-filesystem: symlink planted at the former predictable staging path `codor.tmp` — assert the decoy and the link are untouched.
- Real-filesystem: block the launcher path with a directory so the rename fails — assert the call throws and no `codor.tmp-*` file remains.
- In-memory: make both `rename` and `remove` throw — assert the primary error surfaces, not the cleanup error.

The matching-target and former-`codor.tmp` symlink cases fail against `1660026`; the cleanup case fails against `35f40ce`.

Commands (run at `266cccc`):

- `pnpm install --frozen-lockfile` — passed.
- `pnpm -r build` — passed.
- `pnpm exec vitest run src/launcher-install.spec.ts` (from `packages/cli`) — 13 passed.
- `pnpm --filter @codor/cli test` — 291 passed, 9 failed, 2 skipped.

The 9 failures are unrelated to this change. The branch touches only `launcher-install.ts` and `launcher-install.spec.ts`, so both failing spec files are identical to `main`. Both causes are platform-level (macOS):

- `src/setup-pty.spec.ts` (8): `runPty` invokes `script -qefc` (util-linux syntax); macOS `script` rejects `-f` with `illegal option -- f`.
- `src/index.spec.ts` (1): a worktree path reports `/var/...` against `/private/var/...`.

The Linux CI run for this head passed the build and the serial workspace test steps, supporting the platform attribution. Run the suite through the package script: a bare `vitest run` adds flaky `pair-universal.spec.ts` failures (one appeared in one local run). A full `pnpm -r test` also hits a pre-existing `@codor/adapter-copilot` failure (`/var` vs `/private/var` cwd comparison), unrelated to this change.

## Not tested

- Windows: `installLauncher` is gated behind `platform !== 'win32'` in `setup.ts`, so the rename path is unreachable there.
- End-to-end LaunchAgent restart after the fix on a real machine.

## Out of scope

- `packages/cli/src/setup.ts:848` (`restoreServiceFiles`) uses the same write-through pattern on the update-rollback path. Pre-existing on `main`, not touched here.
- Reconciling `install-cli.sh` and the wizard on a single install mechanism.

