### PR TITLE
fix(antigravity): parse two-column `agy models` output

### DIFF
--- a/packages/adapters/antigravity/NOTES.md
+++ b/packages/adapters/antigravity/NOTES.md
@@ -9,7 +9,8 @@ claimed as live-provider verified.
 
 - `--print <prompt>` runs one prompt non-interactively and emits plain assistant
   text; there is no structured output format.
-- `--model <display name>` accepts names reported by `agy models`.
+- `--model <slug>` selects a model reported by `agy models`; the human-facing
+  display name is also accepted.
 - `--mode <accept-edits|plan>` selects execution behavior;
   `--dangerously-skip-permissions` auto-approves tool permissions.
 - `--conversation <id>` resumes a prior conversation.
@@ -22,12 +23,17 @@ switchboard's supervised child lifecycle.
 <!-- harn:assume adapters-own-their-model-catalog ref=antigravity-model-catalog-notes -->
 ## Model catalog
 
-The probe reported human-facing names such as `Gemini 3.5 Flash (High)`.
-`listModels()` runs `agy models` locally with a fixed argv and timeout, reports
-slug-safe ids to Codor, and owns the reverse mapping back to display names at
-spawn time. The catalog is never hard-coded here. If two names collapse to the
-same slug, discovery fails rather than routing an operator selection to the
-wrong model.
+`agy models` prints one model per line as two tab-separated columns: a model
+slug and a human-facing name, for example
+`gemini-3.8-flash-medium<TAB>Gemini 3.8 Flash (Medium)`. Older builds printed a
+single column and are still accepted.
+
+`listModels()` runs `agy models` locally with a fixed argv and timeout. It uses
+the first column as the model id and passes it to `--model`, which accepts the
+slug. A single-column listing keeps the older slug-safe id with the reverse
+mapping back to the listed value. The catalog is never hard-coded here. If two
+entries collapse to the same id, discovery fails rather than routing an operator
+selection to the wrong model.
 <!-- harn:end adapters-own-their-model-catalog -->
 
 ## Resume boundary

--- a/packages/adapters/antigravity/src/adapter.spec.ts
+++ b/packages/adapters/antigravity/src/adapter.spec.ts
@@ -181,8 +181,7 @@ describe('AntigravityAdapter', () => {
   });
   // harn:end adapter-children-inherit-session-env
 
-  // Behavioral requirement: a two-column `agy models` listing yields slug ids, and the
-  // selected slug reaches `--model` exactly. Not redundant: it pins the argv a picker choice builds.
+  // Verifies: two-column agy output yields slug ids and the selected slug reaches --model exactly.
   it('parses the two-column agy catalog and passes the selected slug to --model', async () => {
     process.env.CODOR_FAKE_ECHO_ARGV = '1';
     const adapter = new AntigravityAdapter(executable());
@@ -195,15 +194,9 @@ describe('AntigravityAdapter', () => {
     }), 'hello');
     const argv = String((events.at(-1) as { final_text?: string }).final_text).split('\n');
     expect(argv[argv.indexOf('--model') + 1]).toBe('gemini-3.5-flash-high');
-
-    const collision = new AntigravityAdapter(executable({
-      models: ['dup-x\tModel One', 'dup-x\tModel Two'],
-    }));
-    await expect(collision.listModels()).rejects.toThrow("collide at slug 'dup-x'");
   });
 
-  // Behavioral requirement: a one-column listing keeps the slug-safe id and maps the selection
-  // back to the listed value. Not redundant: it covers the older-build compatibility path.
+  // Verifies: one-column agy output keeps the slug-safe id and maps the selection back to the listed value.
   it('keeps single-column agy catalogs and their display-name mapping', async () => {
     process.env.CODOR_FAKE_ECHO_ARGV = '1';
     const adapter = new AntigravityAdapter(executable({ models: ['Gemini 3.5 Flash (High)'] }));
@@ -216,9 +209,16 @@ describe('AntigravityAdapter', () => {
     }), 'hello');
     const argv = String((events.at(-1) as { final_text?: string }).final_text).split('\n');
     expect(argv[argv.indexOf('--model') + 1]).toBe('Gemini 3.5 Flash (High)');
+  });
 
-    const collision = new AntigravityAdapter(executable({ models: ['A B', 'A-B'] }));
-    await expect(collision.listModels()).rejects.toThrow("collide at slug 'a-b'");
+  // Verifies: both catalog shapes reject two entries that share an id.
+  it('rejects slug collisions in single-column and two-column catalogs', async () => {
+    const single = new AntigravityAdapter(executable({ models: ['A B', 'A-B'] }));
+    await expect(single.listModels()).rejects.toThrow("collide at slug 'a-b'");
+    const double = new AntigravityAdapter(executable({
+      models: ['dup-x\tModel One', 'dup-x\tModel Two'],
+    }));
+    await expect(double.listModels()).rejects.toThrow("collide at slug 'dup-x'");
   });
 
   it('classifies missing commands and nonzero exits as failed', async () => {

--- a/packages/adapters/antigravity/src/adapter.spec.ts
+++ b/packages/adapters/antigravity/src/adapter.spec.ts
@@ -181,6 +181,8 @@ describe('AntigravityAdapter', () => {
   });
   // harn:end adapter-children-inherit-session-env
 
+  // Behavioral requirement: a two-column `agy models` listing yields slug ids, and the
+  // selected slug reaches `--model` exactly. Not redundant: it pins the argv a picker choice builds.
   it('parses the two-column agy catalog and passes the selected slug to --model', async () => {
     process.env.CODOR_FAKE_ECHO_ARGV = '1';
     const adapter = new AntigravityAdapter(executable());
@@ -200,6 +202,8 @@ describe('AntigravityAdapter', () => {
     await expect(collision.listModels()).rejects.toThrow("collide at slug 'dup-x'");
   });
 
+  // Behavioral requirement: a one-column listing keeps the slug-safe id and maps the selection
+  // back to the listed value. Not redundant: it covers the older-build compatibility path.
   it('keeps single-column agy catalogs and their display-name mapping', async () => {
     process.env.CODOR_FAKE_ECHO_ARGV = '1';
     const adapter = new AntigravityAdapter(executable({ models: ['Gemini 3.5 Flash (High)'] }));
@@ -212,6 +216,9 @@ describe('AntigravityAdapter', () => {
     }), 'hello');
     const argv = String((events.at(-1) as { final_text?: string }).final_text).split('\n');
     expect(argv[argv.indexOf('--model') + 1]).toBe('Gemini 3.5 Flash (High)');
+
+    const collision = new AntigravityAdapter(executable({ models: ['A B', 'A-B'] }));
+    await expect(collision.listModels()).rejects.toThrow("collide at slug 'a-b'");
   });
 
   it('classifies missing commands and nonzero exits as failed', async () => {

--- a/packages/adapters/antigravity/src/adapter.spec.ts
+++ b/packages/adapters/antigravity/src/adapter.spec.ts
@@ -25,7 +25,8 @@ function executable(options: {
   temporary.push(dir);
   const path = join(dir, 'agy');
   const reply = options.reply ?? 'the antigravity reply';
-  const models = options.models ?? ['Gemini 3.5 Flash (High)', 'Gemini 3.1 Pro (High)'];
+  const models = options.models
+    ?? ['gemini-3.5-flash-high\tGemini 3.5 Flash (High)', 'gemini-3.1-pro-high\tGemini 3.1 Pro (High)'];
   const source = `#!/usr/bin/env node
 const fs = require('node:fs');
 const argv = process.argv.slice(2);
@@ -180,7 +181,7 @@ describe('AntigravityAdapter', () => {
   });
   // harn:end adapter-children-inherit-session-env
 
-  it('maps discovered slugs back to display names and rejects collisions', async () => {
+  it('parses the two-column agy catalog and passes the selected slug to --model', async () => {
     process.env.CODOR_FAKE_ECHO_ARGV = '1';
     const adapter = new AntigravityAdapter(executable());
     await expect(adapter.listModels()).resolves.toEqual({
@@ -191,10 +192,26 @@ describe('AntigravityAdapter', () => {
       cwd: process.cwd(), model: 'gemini-3.5-flash-high',
     }), 'hello');
     const argv = String((events.at(-1) as { final_text?: string }).final_text).split('\n');
-    expect(argv[argv.indexOf('--model') + 1]).toBe('Gemini 3.5 Flash (High)');
+    expect(argv[argv.indexOf('--model') + 1]).toBe('gemini-3.5-flash-high');
 
-    const collision = new AntigravityAdapter(executable({ models: ['A B', 'A-B'] }));
-    await expect(collision.listModels()).rejects.toThrow("collide at slug 'a-b'");
+    const collision = new AntigravityAdapter(executable({
+      models: ['dup-x\tModel One', 'dup-x\tModel Two'],
+    }));
+    await expect(collision.listModels()).rejects.toThrow("collide at slug 'dup-x'");
+  });
+
+  it('keeps single-column agy catalogs and their display-name mapping', async () => {
+    process.env.CODOR_FAKE_ECHO_ARGV = '1';
+    const adapter = new AntigravityAdapter(executable({ models: ['Gemini 3.5 Flash (High)'] }));
+    await expect(adapter.listModels()).resolves.toEqual({
+      models: ['gemini-3.5-flash-high'],
+      source: 'discovered',
+    });
+    const events = await collect(adapter, adapter.spawn({
+      cwd: process.cwd(), model: 'gemini-3.5-flash-high',
+    }), 'hello');
+    const argv = String((events.at(-1) as { final_text?: string }).final_text).split('\n');
+    expect(argv[argv.indexOf('--model') + 1]).toBe('Gemini 3.5 Flash (High)');
   });
 
   it('classifies missing commands and nonzero exits as failed', async () => {

--- a/packages/adapters/antigravity/src/adapter.spec.ts
+++ b/packages/adapters/antigravity/src/adapter.spec.ts
@@ -181,7 +181,7 @@ describe('AntigravityAdapter', () => {
   });
   // harn:end adapter-children-inherit-session-env
 
-  // Verifies: two-column agy output yields slug ids and the selected slug reaches --model exactly.
+  // Verifies two-column agy output yields slug ids and --model receives the slug; not redundant because no other test pins the argv a picker selection builds.
   it('parses the two-column agy catalog and passes the selected slug to --model', async () => {
     process.env.CODOR_FAKE_ECHO_ARGV = '1';
     const adapter = new AntigravityAdapter(executable());
@@ -196,7 +196,7 @@ describe('AntigravityAdapter', () => {
     expect(argv[argv.indexOf('--model') + 1]).toBe('gemini-3.5-flash-high');
   });
 
-  // Verifies: one-column agy output keeps the slug-safe id and maps the selection back to the listed value.
+  // Verifies one-column agy output keeps the slug-safe id and maps the selection back to the listed value; not redundant because it is the only older-build compatibility check.
   it('keeps single-column agy catalogs and their display-name mapping', async () => {
     process.env.CODOR_FAKE_ECHO_ARGV = '1';
     const adapter = new AntigravityAdapter(executable({ models: ['Gemini 3.5 Flash (High)'] }));
@@ -211,7 +211,7 @@ describe('AntigravityAdapter', () => {
     expect(argv[argv.indexOf('--model') + 1]).toBe('Gemini 3.5 Flash (High)');
   });
 
-  // Verifies: both catalog shapes reject two entries that share an id.
+  // Verifies both catalog shapes reject two entries that share an id; not redundant because the collision guard is otherwise uncovered.
   it('rejects slug collisions in single-column and two-column catalogs', async () => {
     const single = new AntigravityAdapter(executable({ models: ['A B', 'A-B'] }));
     await expect(single.listModels()).rejects.toThrow("collide at slug 'a-b'");

--- a/packages/adapters/antigravity/src/adapter.ts
+++ b/packages/adapters/antigravity/src/adapter.ts
@@ -142,24 +142,27 @@ export class AntigravityAdapter implements HarnessAdapter {
     if (result.status !== 0) {
       return Promise.reject(new Error(`Command failed: ${this.command} models`));
     }
-    const displays = String(result.stdout ?? '')
+    const lines = String(result.stdout ?? '')
       .split(/\r?\n/)
       .map((line) => line.trim())
       .filter(Boolean);
-    if (displays.length === 0) return Promise.reject(new Error('agy listed no models'));
+    if (lines.length === 0) return Promise.reject(new Error('agy listed no models'));
 
     const next = new Map<string, string>();
-    for (const display of displays) {
-      const slug = antigravitySlug(display);
-      if (slug === '') return Promise.reject(new Error(`agy model '${display}' has no safe slug`));
-      const existing = next.get(slug);
-      if (existing !== undefined && existing !== display) {
+    const seen = new Map<string, string>();
+    for (const line of lines) {
+      const tab = line.indexOf('\t');
+      const slug = tab === -1 ? antigravitySlug(line) : line.slice(0, tab).trim();
+      if (slug === '') return Promise.reject(new Error(`agy model '${line}' has no safe slug`));
+      const existing = seen.get(slug);
+      if (existing !== undefined && existing !== line) {
         return Promise.reject(new Error(`agy model names collide at slug '${slug}'`));
       }
-      next.set(slug, display);
+      seen.set(slug, line);
+      next.set(slug, tab === -1 ? line : slug);
     }
     this.displayNames.clear();
-    for (const [slug, display] of next) this.displayNames.set(slug, display);
+    for (const [slug, modelArg] of next) this.displayNames.set(slug, modelArg);
     return Promise.resolve({ models: [...next.keys()], source: 'discovered' });
   }
   // harn:end adapters-own-their-model-catalog

--- a/packages/adapters/antigravity/src/adapter.ts
+++ b/packages/adapters/antigravity/src/adapter.ts
@@ -114,7 +114,7 @@ export class AntigravityAdapter implements HarnessAdapter {
   // harn:end canonical-spawn-controls-enforced
 
   private readonly children = new WeakMap<Session, ChildProcess>();
-  private readonly displayNames = new Map<string, string>();
+  private readonly modelArgs = new Map<string, string>();
 
   constructor(private readonly command = 'agy') {}
 
@@ -148,22 +148,22 @@ export class AntigravityAdapter implements HarnessAdapter {
       .filter(Boolean);
     if (lines.length === 0) return Promise.reject(new Error('agy listed no models'));
 
-    const next = new Map<string, string>();
-    const seen = new Map<string, string>();
+    const models = new Map<string, string>();
     for (const line of lines) {
       const tab = line.indexOf('\t');
       const slug = tab === -1 ? antigravitySlug(line) : line.slice(0, tab).trim();
       if (slug === '') return Promise.reject(new Error(`agy model '${line}' has no safe slug`));
-      const existing = seen.get(slug);
+      const existing = models.get(slug);
       if (existing !== undefined && existing !== line) {
         return Promise.reject(new Error(`agy model names collide at slug '${slug}'`));
       }
-      seen.set(slug, line);
-      next.set(slug, tab === -1 ? line : slug);
+      models.set(slug, line);
     }
-    this.displayNames.clear();
-    for (const [slug, modelArg] of next) this.displayNames.set(slug, modelArg);
-    return Promise.resolve({ models: [...next.keys()], source: 'discovered' });
+    this.modelArgs.clear();
+    for (const [slug, line] of models) {
+      if (!line.includes('\t')) this.modelArgs.set(slug, line);
+    }
+    return Promise.resolve({ models: [...models.keys()], source: 'discovered' });
   }
   // harn:end adapters-own-their-model-catalog
 
@@ -180,7 +180,7 @@ export class AntigravityAdapter implements HarnessAdapter {
     const logFile = join(tmpdir(), `codor-antigravity-${randomUUID()}.log`);
     const model = session.model === undefined
       ? undefined
-      : this.displayNames.get(session.model) ?? session.model;
+      : this.modelArgs.get(session.model) ?? session.model;
     const child = spawn(this.command, antigravityArgs(session, payload, logFile, model), {
       cwd: session.cwd,
       stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
Fixes #28

## Problem

Antigravity CLI 1.2.2 prints `agy models` as two tab-separated columns per
line: a model slug, then a display name.

```text
gemini-3.8-flash-medium	Gemini 3.8 Flash (Medium)
```

The adapter treated each whole line as a display name. The picker id became the
slug joined with the display (`gemini-3.8-flash-medium-gemini-3.8-flash-medium`),
and `--model` received the raw tab-joined line. `agy` rejected every discovered
model as not recognized.

## Intended result

The picker lists one valid model per row, and the selected value reaches `agy`
as an argument it accepts.

## Change

- `listModels` splits each line on the first tab. The first column is the model
  id passed to `--model`; the second is the display name.
- The two-column id is agy's own slug, used verbatim.
- A single-column listing (older builds) keeps the existing `antigravitySlug`
  derivation and the reverse mapping back to the listed value.
- Collision protection remains unchanged for single-column catalogs and now also
  applies to two-column model ids.
- The fake `agy` output in the spec changes to the two-column format; the spec
  asserts the exact `--model` slug and covers collision rejection for both
  catalog shapes.

## Compatibility decisions

- Two-column slugs are trusted verbatim; observed `agy` slugs are `[a-z0-9.-]`.
- The single-column path is deliberately unchanged, so persisted model ids from
  older builds keep working.
- `ModelCatalog` carries no display names, so the second column is used only to
  distinguish two entries that share an id.

## Harn

This edits prose inside the `harn:assume adapters-own-their-model-catalog` block
in `packages/adapters/antigravity/NOTES.md`. Intended behavior change: the
adapter treats the first `agy models` column as the model id passed to `--model`,
retains the single-column fallback, and still fails discovery on id collisions.
`.harn/assumptions/` and Harn hashes are untouched.

## Tests

```sh
pnpm install --frozen-lockfile                     # passed
pnpm -r build                                      # passed
pnpm --filter @codor/adapter-antigravity test      # 12 passed
pnpm -r --no-bail test                             # exit 1
```

`pnpm -r --no-bail test` fails in 7 package scripts and passes in 13; Antigravity
passes 12/12. The failures are pre-existing relative to this diff. Unmodified
`origin/main` (`03481a3`) reproduced the same seven failed package scripts and the
same broad failure classes. The diff touches only
`packages/adapters/antigravity`. By class:

- `@codor/adapter-copilot`, `@codor/adapter-gemini`, `@codor/adapter-grok`,
  `@codor/adapter-opencode`, `@codor/switchboard`: macOS `/var` vs `/private/var`
  cwd canonicalization and the discovery assertions that depend on it, with
  intermittent timeout cases.
- `@codor/cli`: PTY-driven specs, Windows setup specs running on macOS, setup and
  pairing timeouts, and one worktree path assertion.
- `@codor/web-next`: browser-storage setup failures (`localStorage` undefined),
  plus timeout and state-assertion cases.

Per-package counts differed across parallel full-suite executions, so this report
states failure classes rather than unstable counts.

Live verification on macOS with `agy` 1.2.2:

- `listModels()` returned `discovered`, 14 models, `gemini-3.8-flash-high` first.
- `agy --mode plan --model gemini-3.8-flash-medium --print "Reply with the single word ok."`
  returned `ok`, exit 0.

## Not tested

- Windows: no `agy` install available; the parser is platform-independent but
  was not exercised there.
- Only `agy` 1.2.2 was run live. The single-column older-build path is covered by
  a fixture, not a real binary.
